### PR TITLE
Make setups.{sh,zsh} more POSIX-compliant and setups.zsh work for dash

### DIFF
--- a/bin/mksetup
+++ b/bin/mksetup
@@ -121,8 +121,8 @@ else
     export PYTHONPATH="%(pythondir)s"
 fi
 
-function setup   { eval `%(setup)s           "$@"`; }; export -f setup
-function unsetup { eval `%(setup)s --unsetup "$@"`; }; export -f unsetup
+setup()   { eval `%(setup)s           "$@"`; }; export -f setup
+unsetup() { eval `%(setup)s --unsetup "$@"`; }; export -f unsetup
 
 [[ -n $BASH_COMPLETION ]] && [[ -f "$EUPS_DIR/etc/bash_completion.d/eups" ]] && source "$EUPS_DIR/etc/bash_completion.d/eups"
 """ \
@@ -134,7 +134,7 @@ for s in setup_aliases.keys():
 
 del fd
 
-print "Creating zsh startup script from sh one";
+print "Creating zsh/dash startup script from sh one";
 try:
     ifd = open("setups.sh", "r")
 except IOError, e:
@@ -148,9 +148,8 @@ except IOError, e:
     sys.exit(1)
 
 for line in ifd.readlines():
-    # Modify function declaration syntax
-    line = re.sub(r"^function ((:?un)?setup)", r"\1()", line);
     line = re.sub(r"; export -f (:?un)?setup\s*$", r"\n", line);
+    line = re.sub(r"^\[\[ .*$", r"\n", line);
     
     print >> ofd, line,
 


### PR DESCRIPTION
. switch "function setup() { }" to "setup() {}". This is POSIX, and is
    valid for bash/ksh/sh. I think.

. drop the "[[ -n $BASH_COMPLETIONS" line for setups.zsh, as it is
    neither POSIX nor useful outside of bash

The dash shell is supposed to be a pure POSIX shell. In any case
setups.sh has too many bash-isms for it. "export -f" is necessary for
bash, so I made setups.zsh POSIX-compliant, even though zsh is (much)
further from POSIX than bash is.

Note that "source" is not POSIX, "." is. And that whether functions
are exported is undefined; both dash and "bash --posix" silently
ignore "export $funcname", and dash fails on "export -f $funcname".
