### PR TITLE
EUPS_PYTHON

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -11,11 +11,12 @@ VERSION="`env EUPS_DIR=. PYTHONPATH=python bin/eups --version 2>&1 | awk '/Versi
 #
 prefix = @prefix@
 EUPS_PATH = @EUPS_PATH@
+EUPS_PYTHON = @EUPS_PYTHON@
 EUPS_DIR = @EUPS_DIR@
 SETUP_ALIASES = @SETUP_ALIASES@
 EUPS_DB = $(shell perl -e 'foreach $$d (split(":","$(EUPS_PATH)")) { print "$$d/ups_db\n"}')
 #
-export prefix EUPS_PATH EUPS_DIR SETUP_ALIASES
+export prefix EUPS_PATH EUPS_DIR SETUP_ALIASES EUPS_PYTHON
 #
 SUBDIRS = @MAKE_SUBDIRS@
 

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -10,6 +10,8 @@ all :;
 install :
 	@ ./mksetup $(EUPS_DIR) $(EUPS_PATH) $(SETUP_ALIASES)
 	cp Makefile mksetup setups.*sh eups eups_impl.py eups_setup eups_setup_impl.py eupspkg pkgautoversion $(EUPS_DIR)/bin
+	@ echo "Forcing eups to use system python"
+	@ sed -i 's,\@EUPS_PYTHON\@,$(EUPS_PYTHON),g' $(EUPS_DIR)/bin/*
 	@ echo Building .pyc files
 	@ python -c "import compileall; compileall.compile_dir('$(EUPS_DIR)/bin')"
 

--- a/bin/eups
+++ b/bin/eups
@@ -3,4 +3,4 @@
 #  #!/usr/bin/env python options
 #
 unset PYTHONSTARTUP
-python -S $EUPS_DIR/bin/eups_impl.py "$@"
+@EUPS_PYTHON@ -S $EUPS_DIR/bin/eups_impl.py "$@"

--- a/bin/eups_expandbuild
+++ b/bin/eups_expandbuild
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@EUPS_PYTHON@
 #
 # Expand a .build file, looking for variables @NAME@ and substituting
 # them appropriately:

--- a/bin/eups_impl.py
+++ b/bin/eups_impl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@EUPS_PYTHON@
 #
 # The main eups programme
 #

--- a/bin/eups_remove
+++ b/bin/eups_remove
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@EUPS_PYTHON@
 # -*- python -*-
 #
 # Remove an eups product from the system

--- a/bin/eups_setup
+++ b/bin/eups_setup
@@ -3,4 +3,4 @@
 #  #!/usr/bin/env python options
 #
 unset PYTHONSTARTUP
-python -S $EUPS_DIR/bin/eups_setup_impl.py "$@"
+@EUPS_PYTHON@ -S $EUPS_DIR/bin/eups_setup_impl.py "$@"

--- a/bin/eups_setup_impl.py
+++ b/bin/eups_setup_impl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@EUPS_PYTHON@
 #
 # The EUPS setup programme
 #

--- a/bin/eups_uses
+++ b/bin/eups_uses
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@EUPS_PYTHON@
 # -*- python -*-
 #
 # List all the products which depend on a given product/version

--- a/configure
+++ b/configure
@@ -605,6 +605,7 @@ LIBOBJS
 SETUP_ALIASES
 MAKE_SUBDIRS
 EUPS_DIR
+EUPS_PYTHON
 EUPS_PATH
 target_alias
 host_alias
@@ -649,6 +650,7 @@ enable_option_checking
 with_ups
 with_ups_dir
 with_eups
+with_python
 with_eups_db
 with_eups_dir
 enable_docs
@@ -1286,6 +1288,7 @@ Optional Packages:
   --with-ups=DIR          Typo for --with-eups=DIR
   --with-ups_dir=DIR      Typo for --with-eups_dir=DIR
   --with-eups=DIR         Use DIR as root for installed products (EUPS_PATH)
+  --with-python=BIN       Use BIN python interpreter to run eups
   --with-eups-db=name     Select directory containing NAME from $EUPS_PATH
   --with-eups_dir=DIR     Install eups into DIR/{bin,doc} (equivalent to
                           --prefix)
@@ -1765,6 +1768,37 @@ else
        EUPS_PATH=$EUPS_PATH
     fi
 
+fi
+
+
+
+
+# Check whether --with-python was given.
+if test "${with_python+set}" = set; then
+  withval=$with_python; EUPS_PYTHON=$(echo $withval)
+else
+  EUPS_PYTHON=$(which python)
+    if [ $EUPS_PYTHON != /usr/bin/python ]; then
+      { { $as_echo "$as_me:$LINENO: error: Your current python version isn't /usr/bin/python, please rerun configure with next option
+--with-python=$(which python) will force eups to use your current python version,
+--with-python=/usr/bin/python will force eups to use system-installed python" >&5
+$as_echo "$as_me: error: Your current python version isn't /usr/bin/python, please rerun configure with next option
+--with-python=$(which python) will force eups to use your current python version,
+--with-python=/usr/bin/python will force eups to use system-installed python" >&2;}
+   { (exit 1); exit 1; }; }
+    fi
+
+fi
+
+
+if [ -x $EUPS_PYTHON ]; then
+    $EUPS_PYTHON -c "import sys;print \"EUPS_PYTHON :\ninterpreter : %s\nversion : %s\" % (sys.executable, sys.version)" || { { $as_echo "$as_me:$LINENO: error: $EUPS_PYTHON does not seem to be a valid python interpreter" >&5
+$as_echo "$as_me: error: $EUPS_PYTHON does not seem to be a valid python interpreter" >&2;}
+   { (exit 1); exit 1; }; }
+else
+    { { $as_echo "$as_me:$LINENO: error: $EUPS_PYTHON doesn't exists or doesn't have execute permission granted" >&5
+$as_echo "$as_me: error: $EUPS_PYTHON doesn't exists or doesn't have execute permission granted" >&2;}
+   { (exit 1); exit 1; }; }
 fi
 
 
@@ -2963,4 +2997,3 @@ fi
 
 (export EUPS_DIR=$PWD; cd bin; ./mksetup $EUPS_DIR $EUPS_PATH $SETUP_ALIASES)
 make git.version
-

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,28 @@ AC_ARG_WITH(eups,
    ])
 AC_SUBST(EUPS_PATH)
 
+dnl
+dnl eups python management
+dnl
+AC_ARG_WITH(python,
+   [AS_HELP_STRING(--with-python=BIN, [Use BIN python interpreter to run eups])],
+   [EUPS_PYTHON=$(echo $withval)],
+   [EUPS_PYTHON=$(which python)
+    if [[ $EUPS_PYTHON != /usr/bin/python ]]; then
+      AC_MSG_ERROR([Your current python version isn't /usr/bin/python, please rerun configure with next option 
+--with-python=$(which python) will force eups to use your current python version, 
+--with-python=/usr/bin/python will force eups to use system-installed python])
+    fi
+   ]) 
+
+if [[ -x $EUPS_PYTHON ]]; then
+    $EUPS_PYTHON -c "import sys;print \"EUPS_PYTHON :\ninterpreter : %s\nversion : %s\" % (sys.executable, sys.version)" || AC_MSG_ERROR([$EUPS_PYTHON does not seem to be a valid python interpreter])
+else
+    AC_MSG_ERROR([$EUPS_PYTHON doesn't exists or doesn't have execute permission granted])
+fi
+
+AC_SUBST(EUPS_PYTHON)
+
 # Allow them to use --prefix as an alias for --with-eups_dir
 if test X$prefix != XNONE; then
    with_eups_dir=$prefix


### PR DESCRIPTION
Forcing eups to always use the same python as the one used during eups install :
- Add an option '--with-python' to configure.ac, which will set a
  variable EUPS_PYTHON and make it default to /usr/bin/python when not
  given. That way, when the user installs eups they're guaranteed
  to pick up the system python, or they're _forced_ to be explicit
  about which one they want used.
- Then, use this value to expand the @EUPS_PYTHON@ macros on
  various hash-bang (#!) lines in bin/ folder.

The logic behind this is that EUPS will always default to system python
(/usr/bin/python). If the user wants something different, they have to
be _explicit_ about it. And if someone wants to distribute EUPS via eups
(say, using eupspkg scripts), they'd configure it as:

  $EUPS_PYTHON=`eups admin show python`
  CONFIGURE_OPTIONS='--prefix=$PREFIX --with-python=$EUPS_PYTHON'
