### PR TITLE
BUGFIX on retrieving SHA1 id for a tag :

### DIFF
--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -357,7 +357,7 @@ default_create()
 			# try to avoid checking out everything (it may be a multi-GB repo)
 			(cd tmp && { git checkout -q $GITREV -- ups 2>/dev/null || git checkout -q $GITREV; })
 
-			SHA1=$(cd tmp && git rev-parse HEAD)
+			SHA1=$(cd tmp && git rev-parse --verify $GITREV)
 			append_pkginfo SHA1
 
 			mkdir ups


### PR DESCRIPTION
``` sh
git checkout -q GITREV -- ups
```

returns the last commit id which contains a
ups/ dir similar to the one in GITREV, this can be incorrect if ups/ content
hasn't changed in commits subsequent to GITREV

``` sh
git rev-parse --verify GITREV 
```

seems to work better.

For example :

``` sh
$ git clone --shared -n -q git://git.lsstcorp.org/personal/fjammes/eupspkg/external/python tmp
$ cd tmp
$ git checkout -q 2.7 -- ups
$ git rev-parse HEAD
# returns
a7affa1e34b6b1f45470562911d6fdf67a79e545
# whereas
$ git checkout -f 2.7
$ git rev-parse HEAD
# returns
1a3a5f9c1d98bc1701127d3ba0aa1a83e51e7d95
# and
$ git rev-parse --verify 2.7 
# returns
d297bdd01c7a8eb7ee7c8fa7158cb5fbeb0219de
and
$ git diff d297bdd01c7a8eb7ee7c8fa7158cb5fbeb0219de 1a3a5f9c1d98bc1701127d3ba0aa1a83e51e7d95
# returns nothing
$ git diff d297bdd01c7a8eb7ee7c8fa7158cb5fbeb0219de a7affa1e34b6b1f45470562911d6fdf67a79e545
# returns a difference
```
