### PR TITLE
bugfix: make EUPS independent of $SHELL

### DIFF
--- a/bin/mksetup
+++ b/bin/mksetup
@@ -50,6 +50,8 @@ unique_eups_path = re.sub(r"sys\.argv\[1\]", "\"$EUPS_PATH\"", unique_eups_path)
 unique_eups_path = re.sub(r"sys\.argv\[2\]", "\"%s\"" % prefix, unique_eups_path)
 
 print >> fd, """
+setenv EUPS_SHELL csh
+
 if ("$?EUPS_DIR" == "1" ) then
    setenv PATH `echo $PATH | perl -pe "s|:%(bindir)s||g"`
    if ("$?PYTHONPATH" == "1" ) then
@@ -99,6 +101,8 @@ except IOError, e:
     sys.exit(1)
 
 print >> fd, """
+export EUPS_SHELL=sh
+
 if [ "$EUPS_DIR" != "" ]; then
    PATH=`echo $PATH | perl -pe "s|:%(bindir)s||g"`
    PYTHONPATH=`echo $PYTHONPATH | perl -pe "s|:%(pythondir)s||g"`
@@ -148,6 +152,7 @@ except IOError, e:
     sys.exit(1)
 
 for line in ifd.readlines():
+    line = re.sub(r"^export EUPS_SHELL=.*$", r"export EUPS_SHELL=zsh", line);
     line = re.sub(r"; export -f (:?un)?setup\s*$", r"\n", line);
     line = re.sub(r"^\[\[ .*$", r"\n", line);
     

--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -140,9 +140,9 @@ class Eups(object):
 
         if not shell:
             try:
-                shell = os.environ["SHELL"]
+                shell = os.environ["EUPS_SHELL"]
             except KeyError:
-                raise EupsException("I cannot guess what shell you're running as $SHELL isn't set")
+                raise EupsException("I cannot guess what shell you're running as $EUPS_SHELL isn't set")
 
             if re.search(r"(^|/)(bash|ksh|sh)$", shell):
                 shell = "sh"


### PR DESCRIPTION
Before this patch, EUPS detected the shell it's running under by inspecting
the SHELL environment variable. This is incorrect, since SHELL will point to
the _login_ shell, and not the most recently run shell. This leads to errors
when a user starts a different shell w/o manually resetting the SHELL
variable; e.g.:

```
$ echo $SHELL
/bin/tcsh
$ bash
bash-3.2$ source bin/setups.csh
bash-3.2$ setup some_package
bash: setenv: command not found
```

This patch makes EUPS look for EUPS_SHELL environment variable, which is
defined in setups.[sh|csh|zsh] scripts.  Since the knowledge of the running
shell is needed to support the setup/unsetup aliases, by defining EUPS_SHELL
in the same scripts the two cannot get out of sync.
