### PR TITLE
EUPSPKG_NJOBS: manually set the number of parallel build jobs

### DIFF
--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -1041,7 +1041,7 @@ fi
 
 SCRIPTS=${SCRIPTS:-"$EUPSPKG_SCRIPTS"}		# ':'-delimited list of scripts to source at the end of this script. Used to mass-customize package creation.
 
-NJOBS=$((sysctl -n hw.ncpu || (test -r /proc/cpuinfo && grep processor /proc/cpuinfo | wc -l) || echo 2) 2>/dev/null)   # number of cores on the machine (Darwin & Linux)
+NJOBS=${EUPSPKG_NJOBS:-$((sysctl -n hw.ncpu || (test -r /proc/cpuinfo && grep processor /proc/cpuinfo | wc -l) || echo 2) 2>/dev/null)}   # number of cores on the machine (Darwin & Linux)
 
 UPSTREAM_DIR=${UPSTREAM_DIR:-upstream}			# For "tarball-and-patch" packages (see default_prep()). Default location of source tarballs.
 PATCHES_DIR=${PATCHES_DIR:-patches}			# For "tarball-and-patch" packages (see default_prep()). Default location of patches.


### PR DESCRIPTION
Equivalent to specifying -j$EUPSPKG_NJOBS on the 'make' command line (unless
further overridden by an eupspkg script).
