### PR TITLE
U/fjammes/dm 930

### DIFF
--- a/python/eups/cmd.py
+++ b/python/eups/cmd.py
@@ -2142,8 +2142,13 @@ tag will be installed.
                             help="Prevent automatic assignment of server/global tags")
         self.clo.add_option("--noclean", dest="noclean", action="store_true", default=False,
                             help="Don't clean up after successfully building the product")
-        self.clo.add_option("-j", "--nodepend", dest="nodepend", action="store_true", default=False,
+        self.clo.add_option("-j", "--nodepend", dest="depends", action="store_const",
+                            const=distrib.Repositories.DEPS_NONE,
                             help="Just install product, but not its dependencies")
+        self.clo.add_option("-o", "--onlydepend", dest="depends", action="store_const",
+                            const=distrib.Repositories.DEPS_ONLY,
+                            help="Just install product dependencies, not the product itself")
+        self.clo.set_defaults(depends=distrib.Repositories.DEPS_ALL)
         self.clo.add_option("-N", "--noeups", dest="noeups", action="store_true", default=False,
                             help="Don't attempt to lookup product in eups (always install)")
         self.clo.add_option("-r", "--repository", dest="root", action="append", metavar="BASEURL",
@@ -2300,7 +2305,7 @@ tag will be installed.
                                          self.opts.flavor, 
                                          verbosity=self.opts.verbose, log=log)
             repos.install(productName, versionName, self.opts.updateTags, 
-                          self.opts.alsoTag, self.opts.nodepend, 
+                          self.opts.alsoTag, self.opts.depends,
                           self.opts.noclean, self.opts.noeups, dopts, 
                           self.opts.manifest, self.opts.searchDep)
         except eups.EupsException, e:


### PR DESCRIPTION
This pull-request propose a feature wich enable to install only dependencies for a given product :
example :
eups distrib install qserv --onlydepend -r http://lsst-web.ncsa.illinois.edu/~fjammes/qserv

This feature is usefull for developers, before they run "setup -r ." on the product they want to develop with.

Please use :
git diff --ignore-space-change
in order to see the real code updates. Indeed, i've removed trailing whitespaces and it induces a lot of modified lines.
