### PR TITLE
U/fjammes/dm 950

### DIFF
--- a/python/eups/distrib/Repositories.py
+++ b/python/eups/distrib/Repositories.py
@@ -421,7 +421,8 @@ class Repositories(object):
                         continue
                 ances.append(pver)
 
-            if nodepend and prod.product != product and prod.version != version:
+            is_product = (prod.product == product and prod.version == version)
+            if nodepend and not is_product:
                 continue
 
             if pver in installed:


### PR DESCRIPTION
For next case :

| product | version |
| --- | --- |
| PROD | 1 |
| DEP1 | 1 |
| DEP2 | 2 |

It seems the algorithms will install PROD-v1 but also DEP1-v1 because i has the same version number.

This pull request propose a trivial fix.
Please note that no real tests of this bug have been performs for time constraints.
