### PR TITLE
Fix 'eups distrib install' breakage caused by 119236b

### DIFF
--- a/python/eups/distrib/eupspkg.py
+++ b/python/eups/distrib/eupspkg.py
@@ -939,6 +939,9 @@ TAGLIST_DIR = tags
 set -xe
 cd %(buildDir)s
 
+# make sure the EUPS environment is set up
+. "$EUPS_DIR/bin/setups.sh"
+
 # sanitize the environment: unsetup any packages that were setup-ed
 #
 # NOTE: this has been disabled as there are legitimate reasons to have EUPS


### PR DESCRIPTION
Commit 119236b stopped exporting setup() and unsetup() functions, breaking 'eups distrib install'.  We now source setups.sh at the beginning of eupspkg-generated build script to make sure the EUPS environment is correctly set up.

The motivation for the change was posix compliance (especially in light of the shellshock exploit), so reverting the eups changes is not appropriate.
