### PR TITLE
ensure that eups is working when getpwuid is not (e.g. on NERSC hopper)

### DIFF
--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -1,7 +1,7 @@
 """
 The Eups class 
 """
-import glob, re, os, pwd, shutil, sys, time
+import glob, re, os, shutil, sys, time
 import filecmp
 import fnmatch
 import tempfile

--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -185,7 +185,7 @@ class Eups(object):
         self.oldAliases = {}            # initial value of aliases.  This is a bit of a fake, as we
                                         # don't know how to set it but (un)?setAlias knows how to handle this
 
-        self.who = re.sub(r",.*", "", pwd.getpwuid(os.getuid())[4])
+        self.who = utils.getUserName(full=True)
 
         if root:
             root = os.path.expanduser(root)
@@ -338,7 +338,7 @@ class Eups(object):
         # 
         # load up the recognized tags.
         # 
-        user = pwd.getpwuid(os.geteuid())[0] # our username is always a valid user tag (if not already global)
+        user = utils.getUserName() # our username is always a valid user tag (if not already global)
         if hooks.config.Eups.userTags.count(user) == 0 and \
            hooks.config.Eups.globalTags.count(user) == 0:
             hooks.config.Eups.userTags.append(user)

--- a/python/eups/db/ChainFile.py
+++ b/python/eups/db/ChainFile.py
@@ -1,7 +1,7 @@
 import os, re, sys, pwd
-from eups.utils import ctimeTZ, isRealFilename, stdwarn, stderr
+from eups.utils import ctimeTZ, isRealFilename, stdwarn, stderr, getUserName
 
-who = re.sub(r",.*", "", pwd.getpwuid(os.getuid())[4])
+who = getUserName(full=True)
 
 class ChainFile(object):
     """

--- a/python/eups/db/ChainFile.py
+++ b/python/eups/db/ChainFile.py
@@ -1,4 +1,4 @@
-import os, re, sys, pwd
+import os, re, sys
 from eups.utils import ctimeTZ, isRealFilename, stdwarn, stderr, getUserName
 
 who = getUserName(full=True)

--- a/python/eups/db/VersionFile.py
+++ b/python/eups/db/VersionFile.py
@@ -1,4 +1,4 @@
-import os, re, sys, pwd
+import os, re, sys
 from eups.Product import Product
 from eups.exceptions import ProductNotFound
 from eups.utils import ctimeTZ, isRealFilename

--- a/python/eups/db/VersionFile.py
+++ b/python/eups/db/VersionFile.py
@@ -4,7 +4,7 @@ from eups.exceptions import ProductNotFound
 from eups.utils import ctimeTZ, isRealFilename
 import eups.utils
 
-who = re.sub(r",.*", "", pwd.getpwuid(os.getuid())[4])
+who = eups.utils.getUserName(full=True)
 defaultProductUpsDir = "ups"
 
 class VersionFile(object):

--- a/python/eups/lock.py
+++ b/python/eups/lock.py
@@ -135,7 +135,6 @@ def takeLocks(cmdName, path, lockType, nolocks=False, ntry=10, verbose=0):
             #
             # Create a file in it
             #
-            import pwd
             who = utils.getUserName()
             pid = os.getpid()
 

--- a/python/eups/lock.py
+++ b/python/eups/lock.py
@@ -136,7 +136,7 @@ def takeLocks(cmdName, path, lockType, nolocks=False, ntry=10, verbose=0):
             # Create a file in it
             #
             import pwd
-            who = pwd.getpwuid(os.geteuid())[0]
+            who = utils.getUserName()
             pid = os.getpid()
 
             lockFile = "%s-%s.%d" % (lockTypeName, who, pid)

--- a/python/eups/stack/ProductStack.py
+++ b/python/eups/stack/ProductStack.py
@@ -17,7 +17,7 @@ persistVersionName = "1.3.0"
 userPrefix = "user:"     
 
 dotre = re.compile(r'\.')
-who = pwd.getpwuid(os.geteuid())[0]
+who = utils.getUserName()
 
 class ProductStack(object):
     """

--- a/python/eups/stack/ProductStack.py
+++ b/python/eups/stack/ProductStack.py
@@ -1,4 +1,4 @@
-import pwd, re, os, cPickle, sys
+import re, os, cPickle, sys
 from eups import utils
 from eups import Product
 from ProductFamily import ProductFamily

--- a/python/eups/tags.py
+++ b/python/eups/tags.py
@@ -1,4 +1,4 @@
-import fnmatch, os, pwd, re, sys
+import fnmatch, os, re, sys
 import hooks, utils
 from exceptions import EupsException
 

--- a/python/eups/tags.py
+++ b/python/eups/tags.py
@@ -2,7 +2,7 @@ import fnmatch, os, pwd, re, sys
 import hooks, utils
 from exceptions import EupsException
 
-who = pwd.getpwuid(os.geteuid())[0]
+who = utils.getUserName()
 
 tagListFileExt = "tags"
 tagListFileTmpl = "%s." + tagListFileExt

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -18,14 +18,12 @@ def getUserName(full=False):
         print >> stdwarn, "Warning: getpwuid failed, guessing username from LOGNAME or USER variable"
     
     try:
-        who = os.environ['LOGNAME']
-        return who
+        return os.environ['LOGNAME']
     except KeyError:
         print >> stdwarn, "Warning: LOGNAME variable undefined, trying USER"
 
     try:
-        who = os.environ['USER']
-        return who
+        return os.environ['USER']
     except KeyError:
         raise RuntimeError, "Cannot find out the user name. getpwuid failed and neither LOGNAME nor USER environment variable is defined"
 

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -1,9 +1,27 @@
 """
 Utility functions used across EUPS classes.
 """
-import time, os, sys, glob, re, shutil, tempfile
+import time, os, sys, glob, re, shutil, tempfile, pwd
 from cStringIO import StringIO
 
+def getUserName(full=False):
+    # get the current username
+    # if getpwuid fails use USER environment variable
+    euid = os.geteuid()
+    try:
+        if full:
+            who = re.sub(r",.*", "", pwd.getpwuid(os.getuid())[4])
+        else:
+            who = pwd.getpwuid(os.geteuid())[0]
+    except KeyError:
+        print >> stdwarn, "Warning: getpwuid failed, guessing username from USER variable"
+        try:
+            who = os.environ['USER']
+        except KeyError:
+            raise RuntimeError, "Cannot find out the user name. getpwuid failed and USER environment variable is undefined"
+    return who
+
+            
 def _svnRevision(file=None, lastChanged=False):
     """Return file's Revision as a string; if file is None return
     a tuple (oldestRevision, youngestRevision, flags) as reported

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -6,20 +6,28 @@ from cStringIO import StringIO
 
 def getUserName(full=False):
     # get the current username
-    # if getpwuid fails use USER environment variable
+    # if getpwuid fails use LOGNAME or USER environment variable
     euid = os.geteuid()
     try:
         if full:
             who = re.sub(r",.*", "", pwd.getpwuid(os.getuid())[4])
         else:
             who = pwd.getpwuid(os.geteuid())[0]
+        return who
     except KeyError:
-        print >> stdwarn, "Warning: getpwuid failed, guessing username from USER variable"
-        try:
-            who = os.environ['USER']
-        except KeyError:
-            raise RuntimeError, "Cannot find out the user name. getpwuid failed and USER environment variable is undefined"
-    return who
+        print >> stdwarn, "Warning: getpwuid failed, guessing username from LOGNAME or USER variable"
+    
+    try:
+        who = os.environ['LOGNAME']
+        return who
+    except KeyError:
+        print >> stdwarn, "Warning: LOGNAME variable undefined, trying USER"
+
+    try:
+        who = os.environ['USER']
+        return who
+    except KeyError:
+        raise RuntimeError, "Cannot find out the user name. getpwuid failed and neither LOGNAME nor USER environment variable is defined"
 
             
 def _svnRevision(file=None, lastChanged=False):

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -14,27 +14,26 @@ def getUserName(full=False):
     
     euid = os.geteuid()
     try:
+        pw = pwd.getpwuid(euid)
         getUserName.who = {
-            True: re.sub(r",.*", "", pwd.getpwuid(os.getuid())[4]),
-            False : pwd.getpwuid(os.geteuid())[0]
+            False : pw[0],
+            True: re.sub(r",.*", "", pw[4])
             }
-        return getUserName.who[full]
     except KeyError:
         print >> stdwarn, "Warning: getpwuid failed, guessing username from LOGNAME or USER variable"
-    
-    try:
-        getUserName.who = dict(zip([True,False],[os.environ['LOGNAME']]*2))
-        return getUserName.who
-    except KeyError:
-        print >> stdwarn, "Warning: LOGNAME variable undefined, trying USER"
+        key = None 
+        if 'LOGNAME' in os.environ:
+            key = 'LOGNAME'
+        elif 'USER' in os.environ:
+            print >> stdwarn, "Warning: LOGNAME variable undefined, trying USER"
+            key = 'USER'    
+        if key is None:
+            print >> stdwarn, "Cannot find out the user name. getpwuid failed and neither LOGNAME nor USER environment variable is defined. Assuming '(unknown user)'"
+            getUserName.who = dict(zip([False,True],['(unkwnown user)']*2))
+        else:
+            getUserName.who = dict(zip([False,True],[os.environ[key]]*2))
 
-    try:
-        getUserName.who = dict(zip([True,False],[os.environ['USER']]*2))
-        return getUserName.who
-    except KeyError:
-        print >> stdwarn, "Cannot find out the user name. getpwuid failed and neither LOGNAME nor USER environment variable is defined. Assuming '(unknown user)'"
-        getUserName.who = dict(zip([True,False],['(unkwnown user)']*2))
-        return getUserName.who
+    return getUserName.who[full]
 
             
 def _svnRevision(file=None, lastChanged=False):


### PR DESCRIPTION
Hi, 

By default eups fails on platforms where getpwuid doesn't work.
```
Traceback (most recent call last):
  File "/global/homes/k/koposov/lsst92new/Linux64/obs_sdss/9.0+11/bin/processCcdSdss.py", line 23, in <module>
    from lsst.obs.sdss.processCcdSdss import ProcessCcdSdssTask
  File "/global/homes/k/koposov/lsst92new/Linux64/obs_sdss/9.0+11/python/lsst/obs/sdss/__init__.py", line 23, in <module>  
    from sdssMapper import *
  File "/global/homes/k/koposov/lsst92new/Linux64/obs_sdss/9.0+11/python/lsst/obs/sdss/sdssMapper.py", line 25, in <module>
    from lsst.daf.butlerUtils import CameraMapper, exposureFromImage
  File "/global/homes/k/koposov/lsst92new/Linux64/daf_butlerUtils/9.0+8/python/lsst/daf/butlerUtils/__init__.py", line 27, in <module>
    from cameraMapper import *
  File "/global/homes/k/koposov/lsst92new/Linux64/daf_butlerUtils/9.0+8/python/lsst/daf/butlerUtils/cameraMapper.py", line 30, in <module>
    import eups
  File "/global/homes/k/koposov/lsst92new/eups/python/eups/__init__.py", line 2, in <module>
    from tags       import Tags, Tag, TagNotRecognized
  File "/global/homes/k/koposov/lsst92new/eups/python/eups/tags.py", line 5, in <module>
    who = pwd.getpwuid(os.geteuid())[0]
KeyError: 'getpwuid(): uid not found: 63122'
```

Here is the patch which uses the USER environment variable instead if getpwuid doesnt' have the current user ID.
It seems to fix the issue on NERSC. 

One way to test this patch is to temporarily remove the user from passwd. 

 Sergey
