### PR TITLE
Tweak call to bin/mksetup in configure

### DIFF
--- a/configure
+++ b/configure
@@ -2993,5 +2993,5 @@ if [ X$SETUP_ALIASES != X ]; then
    echo "addAlias(`echo $SETUP_ALIASES | sed -e 's/^.*://'`, unsetup \$@)" >> ups/eups.table
 fi
 
-(export EUPS_DIR=$PWD; cd bin; $EUPS_PYTHON ./mksetup $EUPS_DIR $EUPS_PATH $SETUP_ALIASES)
+(export EUPS_DIR=$PWD; cd bin; $EUPS_PYTHON ./mksetup $EUPS_DIR $EUPS_PATH $SETUP_ALIASES) || exit $?
 make git.version

--- a/configure.ac
+++ b/configure.ac
@@ -120,5 +120,5 @@ if [[ X$SETUP_ALIASES != X ]]; then
    echo "addAlias(`echo $SETUP_ALIASES | sed -e 's/^.*://'`, unsetup \$@)" >> ups/eups.table
 fi
 
-(export EUPS_DIR=$PWD; cd bin; $EUPS_PYTHON ./mksetup $EUPS_DIR $EUPS_PATH $SETUP_ALIASES)
+(export EUPS_DIR=$PWD; cd bin; $EUPS_PYTHON ./mksetup $EUPS_DIR $EUPS_PATH $SETUP_ALIASES) || exit $?
 make git.version


### PR DESCRIPTION
These minor changes enable LSST's `newinstall.sh` to:
- Specify the version of Python used to execute `bin/mksetup`;
- Detect if `./configure` fails.

Thereby resolving [DM-1730](https://jira.lsstcorp.org/browse/DM-1730).
