### PR TITLE
Improve TaP package detection.

### DIFF
--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -672,8 +672,9 @@ default_prep()
 	# to apply once all tarballs have been expanded.
 	#
 	# To be recognized as at TaP package, there must be no files (other
-	# than those starting with a dot) in the package root directory, and
-	# there must be a directory named 'upstream'
+	# than those starting with a dot) in the package root directory unless
+	# the file ".tap_package" exists, and there must be a directory named
+	# 'upstream'
 
 	if [[ -d "$UPSTREAM_DIR" ]]; then
 	
@@ -683,8 +684,8 @@ default_prep()
 		fi
 
 		# verify that there are no files (other than .* or _*) in $pkgdir
-		# packagers: it's possible override this ckeck with TAP_PACKAGE=1
-		if [[ "$TAP_PACKAGE" != 1 && ! -z $(find . -maxdepth 1 -mindepth 1 ! -name ".*" ! -name "_*" -a -type f) ]]; then
+		# packagers: it's possible to override this check by creating .tap_package
+		if [[ ! -f ".tap_package" && ! -z $(find . -maxdepth 1 -mindepth 1 ! -name ".*" ! -name "_*" -a -type f) ]]; then
 			die "files found in root directory; guessing this is not a TaP package."
 		fi
 

--- a/python/eups/distrib/eupspkg.py
+++ b/python/eups/distrib/eupspkg.py
@@ -385,10 +385,10 @@ r"""
 
        TaP         -- the "tarball-and-patch" package; if a directory named
                       'upstream' exists in package root (and no other files
-                      are found there), extract any tarballs from 'upstream'
-                      and apply any patches found in 'patches', before
-                      proceeding to autodetect the build system as described
-                      above.
+                      are found there or the file ".tap_package" exists),
+                      extract any tarballs from 'upstream' and apply any
+                      patches found in 'patches', before proceeding to
+                      autodetect the build system as described above.
 
                       This is useful for packages created out of git
                       repositories that are just containers for external


### PR DESCRIPTION
Instead of looking for an environment variable (which is hard to set) or
for the lack of files in the root directory, look for an explicit
".tap_package" file (in addition to looking for the "upstream"
directory).

This allows packages to contain other files like "README.md", providing a place to document how the external dependency was packaged, what patches were necessary, etc.