### PR TITLE
eupspkg: Don't use SCONSFLAGS from the environment

### DIFF
--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -1136,7 +1136,7 @@ PYSETUP_INSTALL_OPTIONS=${PYSETUP_INSTALL_OPTIONS:-"--home $PREFIX --prefix="}	#
 export CC=${CC:-cc}				# Autoconf prefers to look for gcc first, and the proper thing is to default to cc. This helps on Darwin.
 export CXX=${CXX:-c++}				# Autoconf prefers to look for gcc first, and the proper thing is to default to c++. This helps on Darwin.
 
-export SCONSFLAGS=${SCONSFLAGS:-"opt=3"}	# Default scons flags
+export SCONSFLAGS=${EUPSPKG_SCONSFLAGS:-"opt=3"}	# Default scons flags
 
 ##################################################################
 #

--- a/python/eups/distrib/eupspkg.py
+++ b/python/eups/distrib/eupspkg.py
@@ -675,6 +675,7 @@ import sys, os, shutil, tempfile, pipes, stat
 from . import Distrib as eupsDistrib
 from . import server as eupsServer
 
+issued_sconsflags_warning = False
 
 class Distrib(eupsDistrib.DefaultDistrib):
     """A class to implement product distribution based on packages
@@ -933,6 +934,18 @@ TAGLIST_DIR = tags
         # Make sure the buildDir is empty (to avoid interference from failed builds)
         shutil.rmtree(buildDir)
         os.mkdir(buildDir)
+
+        # eupspkg ignores SCONSFLAGS; this may be surprising to some users, so
+        # print out a warning if we detect SCONSFLAGS are set in the environment.
+        # n.b. -- to pass SCONSFLAGS to eupspkg, set EUPSPKG_SCONSFLAGS
+        global issued_sconsflags_warning
+        if not issued_sconsflags_warning:
+            if "SCONSFLAGS" in os.environ and "EUPSPKG_SCONSFLAGS" not in os.environ and self.verbose >= 0:
+                print("\n"
+                      "**NOTICE**: you have SCONSFLAGS set in your environment; we will ignore it.\n"
+                      "If you want to pass SCONSFLAGS to `eups distrib install', please set the\n"
+                      "EUPSPKG_SCONSFLAGS environmental variable.", file=self.log)
+            issued_sconsflags_warning = True
 
         # Construct the build script
         q = pipes.quote


### PR DESCRIPTION
Instead, use EUPSPKG_SCONSFLAGS to override SCONSFLAGS used 
by eupspkg when building products.

This avoids nasty surprises where a developer may have SCONSFLAGS set 
for every-day development work, but these then get picked up by eupspkg.

See https://jira.lsstcorp.org/browse/DM-1053?focusedCommentId=32844 for details.