### PR TITLE
eupspkg-generated versions on master are referenced to tags (LSST DM-2169)

### DIFF
--- a/bin/pkgautoversion
+++ b/bin/pkgautoversion
@@ -158,6 +158,13 @@ git_version()
 		if [[ -z $BRANCH ]]; then
 			# Commit is not on any branch (orphaned)
 			RES=($ABBRSHA $DIRTY)
+		elif [[ $BRANCH = master ]]; then
+			local DESC=$(git describe --first-parent --match "$TAG_PATTERN" 2>/dev/null)
+			if [[ -z $DESC ]]; then
+				RES=($BRANCH g$ABBRSHA $DIRTY )
+			else
+				RES=($DESC $DIRTY )
+			fi
 		else
 			RES=($BRANCH g$ABBRSHA $DIRTY )
 		fi
@@ -323,15 +330,15 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 
 				ut0 Commit away from the tag
 				_git_add_commit newfile
-				ut "git_version --dirty" == "master-g$(git rev-parse --short=10 HEAD)"
+				ut "git_version --dirty" == "1.1-1-g$(git rev-parse --short=10 HEAD)"
 
 				ut0 Commit away from the tag
 				_git_add_commit newfile2
-				ut "git_version --dirty" == "master-g$(git rev-parse --short=10 HEAD)"
+				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=10 HEAD)"
 
 				ut0 Dirty commit away from the tag
 				echo "stuff" >> newfile2
-				ut "git_version --dirty" == "master-g$(git rev-parse --short=10 HEAD)-dirty"
+				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=10 HEAD)-dirty"
 				git reset --hard -q
 
 
@@ -350,7 +357,7 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 				ut0 Where --first-parent makes a difference
 				git checkout -q master > /dev/null
 				git merge next2 -m "Merge" > /dev/null
-				ut "git_version --dirty" == "master-g$(git rev-parse --short=10 HEAD)"
+				ut "git_version --dirty" == "1.1-3-g$(git rev-parse --short=10 HEAD)"
 
 				#git log --decorate --oneline --graph --all
 				#git describe

--- a/bin/pkgautoversion
+++ b/bin/pkgautoversion
@@ -355,15 +355,15 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 				#git log --decorate --oneline --graph --all
 				#git describe
 				#git describe --first-parent
+
+				echo
+				ut_exit
 			)
 		)
-		echo
 	}
 
 	_ut_earliest_version
 	_ut_git_version
-
-	ut_exit
 fi
 
 ##################### ---- END UNIT TESTS ---- #####################

--- a/lib/bunit.sh
+++ b/lib/bunit.sh
@@ -54,7 +54,7 @@ ut_exit()
 	# check if any unit test failed, exit if so
 
 	if [[ ! -z $_UT_FAIL ]]; then
-		echo **** error: some unit tests failed.
+		echo '****' error: some unit tests failed.
 		exit -1
 	else
 		echo all unit tests passed.


### PR DESCRIPTION
As stated in the original problem description, this change will, for commits on master only:
> provide a number that is derived from the most recent tag, sorts properly almost all the time, and is still traceable back to the original git commit

as opposed to using just "master-g{SHA}".

This PR also fixes minor bugs in the unit testing framework and unit tests.