### PR TITLE
distrib: pass force down to table file expansion

### DIFF
--- a/python/eups/distrib/Distrib.py
+++ b/python/eups/distrib/Distrib.py
@@ -797,7 +797,7 @@ class DefaultDistrib(Distrib):
             productList = dict([(p.product, p.version) for p in productDeps])
 
             eups.table.expandTableFile(self.Eups, outTable, inTable, productList,
-                                       toplevelName=product, recurse=False)
+                                       toplevelName=product, recurse=False, force=force)
             return True
 
         #


### PR DESCRIPTION
The table file expansion respects 'force', and it's sometimes
helpful to get you out of a jam.