### PR TITLE
Performance optimizations for large product stacks

### DIFF
--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -1026,6 +1026,16 @@ The what argument tells us what sort of state is expected (allowed values are de
                 if self.cmdName != "setup":
                     print >> sys.stderr, "%-15s %s" % (product.name, product.version)
 
+        # Hack around Product.getTable() slowness, by internally caching Product instances
+        # FIXME: Should be removed once the Product.getTable() bottleneck is resolved
+        try:
+            product = self._productCache[product]
+        except AttributeError:
+            self._productCache = dict()
+            self._productCache[product] = product
+        except KeyError:
+            self._productCache[product] = product
+
         return [product, vroReason]
 
     def findProduct(self, name, version=None, eupsPathDirs=None, flavor=None,

--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -2984,12 +2984,9 @@ The what argument tells us what sort of state is expected (allowed values are de
                 out.append(prod)
 
         #
-        # Make productList entries uniq; would use a set but they are too newfangled
+        # Make productList entries uniq
         #
-        productList = []
-        for p in out:
-            if not p in productList:
-                productList.append(p)
+        productList = list(set(out))
 
         return productList                
 

--- a/python/eups/db/ChainFile.py
+++ b/python/eups/db/ChainFile.py
@@ -68,10 +68,10 @@ class ChainFile(object):
         @param flavor : the name of the flavor to get the tagged versions for. 
         @return string : the version tag is assigned to
         """
-        if not self.info.has_key(flavor) or \
-           not self.info[flavor].has_key("version"):
+        try:
+            return self.info[flavor]["version"]
+        except KeyError:
             return None
-        return self.info[flavor]["version"]
 
     def setVersion(self, version, flavors=None):
         """

--- a/python/eups/db/ChainFile.py
+++ b/python/eups/db/ChainFile.py
@@ -1,4 +1,4 @@
-import os, re, sys
+import os, re, sys, errno
 from eups.utils import ctimeTZ, isRealFilename, stdwarn, stderr, getUserName
 
 who = getUserName(full=True)
@@ -37,8 +37,13 @@ class ChainFile(object):
         # name and its value is a properties set of named metadata.
         self.info = {}
 
-        if readFile and os.path.exists(self.file):
-            self._read(self.file, verbosity)
+        if readFile:
+            try:
+                self._read(self.file, verbosity)
+            except IOError, e:
+                # It's not an error if the file didn't exist
+                if e.errno != errno.ENOENT:
+	            raise
 
 
     def getFlavors(self):
@@ -175,6 +180,9 @@ CHAIN = %s
 
         fd.close()
 
+    REGEX_KEYVAL = re.compile(r"^(\w+)\s*=\s*(.*)", flags = re.IGNORECASE)
+    REGEX_GROUPEND = re.compile(r"^(End|Group)\s*:")
+
     def _read(self, file=None, verbosity=0):
         """
         read in data from a file, possibly overwring previously tagged products
@@ -186,31 +194,28 @@ CHAIN = %s
         fd = open(file)
 
         flavor = None
-        lineNo = 0           # line number in input file, for diagnostics
-        for line in fd.readlines():
-            lineNo += 1
-            line = line.strip()
-            line = re.sub(r"#.*$", "", line)
-            if not line:
+        for at, line in enumerate(fd):
+            line = line.lstrip()  # remove any leading whitespace
+            if not line or line.startswith('#'):
                 continue
 
             #
             # Get key = value
             #
-            mat = re.search(r"^(\w+)\s*=\s*(.*)", line, re.IGNORECASE)
+            mat = ChainFile.REGEX_KEYVAL.search(line)
             if mat:
                 key = mat.group(1).lower()
-                value = re.sub(r"^\"|\"$", "", mat.group(2))
+                value = mat.group(2).strip('"')
 
             #
             # Ignore Group: and End:
             #
-            elif re.search(r"^(End|Group)\s*:", line):
+            elif ChainFile.REGEX_GROUPEND.search(line):
                 continue
             else:
                 raise RuntimeError, \
                       ("Unexpected line \"%s\" at %s:%d" % \
-                         (line, self.file, lineNo))
+                         (line, self.file, at+1))
 
             #
             # Check for information about product
@@ -219,7 +224,7 @@ CHAIN = %s
                 if value.lower() not in ["chain", "version"]:
                     raise RuntimeError, \
                           ("Expected \"File = Version\"; saw \"%s\" at %s:%d" \
-                             % (line, self.file, lineNo))
+                             % (line, self.file, at+1))
 
             elif key == "product":
                 if not self.name:
@@ -243,8 +248,6 @@ CHAIN = %s
                 flavor = value
                 self.info[flavor] = {}
             else:
-                value = re.sub(r"^\"(.*)\"$", r"\1", mat.group(2)) # strip ""
-
                 if key == "qualifiers":
                     if value:           # flavor becomes e.g. Linux:build
                         newflavor = "%s:%s" % (flavor, value)

--- a/python/eups/db/Database.py
+++ b/python/eups/db/Database.py
@@ -683,6 +683,12 @@ class _Database(object):
         @param dbrootdir    directory where to look for file times.  If None,
                                defaults to database root.  
         """
+        # HACK: If the user is _certain_ that the caches are up-to-date,
+        #       allow them to say so. This is a hack to speed up builds
+        #       on systems with thousands of products installed
+        if os.environ.get("_EUPS_ASSUME_CACHES_UP_TO_DATE", "0") == "1":
+            return False
+
         if not dbrootdir:
             dbrootdir = self.dbpath
         proddirs = map(lambda d: os.path.join(self.dbpath, d), self.findProductNames())

--- a/python/eups/table.py
+++ b/python/eups/table.py
@@ -1374,7 +1374,7 @@ def expandTableFile(Eups, ofd, ifd, productList, versionRegexp=None, force=False
             version = productList[productName]
         else:
             try:
-                version = eups.getSetupVersion(productName)
+                version = eups.getSetupVersion(productName, eupsenv=Eups)
             except ProductNotFound:
                 notFound[productName] = True
                 if not optional:

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -151,12 +151,12 @@ def setupEnvNameFor(productName):
     return the name of the environment variable that provides the 
     setup information for a product.  This is of the form "setupEnvPrefix() + prod".
     """
-    name = setupEnvPrefix() + productName
+    name = setupEnvPrefix() + productName.upper()
 
     if os.environ.has_key(name):
         return name                 # exact match
 
-    envNames = filter(lambda k: re.search(r"^%s$" % name, k, re.IGNORECASE), os.environ.keys())
+    envNames = [ k for k in os.environ if k.upper() == name ]
     if envNames:
         return envNames[0]
     else:


### PR DESCRIPTION
A series of performance optimizations for large installations (thousands of products), identified through profiling.

Together with related optimizations in sconsUtils, speeds up the product builds on lsst-dev by 1.5x-2.5x, depending on the product. E.g.:

Before:
```
ndarray: master-g7408a83a3a+4 ................................................ok (138.8 sec).
daf_persistence: 10.0+23 ......................................................ok (124.6 sec).
```
After:
```
ndarray: master-g7408a83a3a+5 .......................ok (87.5 sec).
daf_persistence: 10.0+23 ....................ok (55.2 sec).
```