### PR TITLE
Remove unused Product.persist() and .unpersist() methods

### DIFF
--- a/python/eups/Product.py
+++ b/python/eups/Product.py
@@ -453,20 +453,6 @@ class Product(object):
 
         return config
 
-    def persist(self, fd):
-        out = (self.name, self.version, self.flavor, self.dir, self.tablefile,
-               self.tags, self.db, self._table)
-        pickle.dump(out, fd, protocol=2);
-
-    # @staticmethod   # requires python 2.4
-    def unpersist(fd):
-        """return a Product instance restored from a file persistence"""
-        p = pickle.load(fd);
-        out = Product(p[0], p[1], p[2], p[3], p[4], p[5], p[6])
-        out._table = p[7]
-        return out
-    unpersist = staticmethod(unpersist)  # should work as of python 2.2
-
     # this replaces from initFromDirectory()
     # @staticmethod   # requires python 2.4
     def createLocal(productName, productDir, flavor=None, checkForTable=True, tablefile=None):

--- a/tests/testProduct.py
+++ b/tests/testProduct.py
@@ -36,20 +36,6 @@ class ProductTestCase(unittest.TestCase):
         self.assertIn("stable", p.tags)
         self.assertIn("mine", p.tags)
 
-    def testPersist(self):
-        fd = open("test_product.pickle", "wb")
-        self.prod.persist(fd)
-        fd.close()
-        fd = open("test_product.pickle", "rb")
-        p = Product.unpersist(fd)
-
-        self.assertEqual(self.prod.name, p.name)
-        self.assertEqual(self.prod.version, p.version)
-        self.assertEqual(self.prod.dir, p.dir)
-        self.assertEqual(self.prod.db, p.db)
-        self.assert_(self.prod._table is None)
-        self.assert_(self.prod.tablefile is None)
-
     def testStackRoot(self):
         self.assert_(self.prod.stackRoot() is None)
         self.prod.db = os.path.join(self.prod.dir, "ups_db")


### PR DESCRIPTION
I found these while looking for other places that may have race conditions while pickling. I think they aren't used anywhere, and look like a leftover from an abandoned experiment. They may be confusing to newcomers, who may be tempted to use them.
