### PR TITLE
pkgautoversion: only match conforming tags passed via the command line

### DIFF
--- a/bin/pkgautoversion
+++ b/bin/pkgautoversion
@@ -159,7 +159,7 @@ git_version()
 			# Commit is not on any branch (orphaned)
 			RES=($ABBRSHA $DIRTY)
 		elif [[ $BRANCH = master ]]; then
-			local DESC=$(git describe --abbrev=10 --first-parent --match "$TAG_PATTERN" 2>/dev/null)
+			local DESC=$(git describe --first-parent --match "$TAG_PATTERN" 2>/dev/null)
 			if [[ -z $DESC ]]; then
 				RES=($BRANCH g$ABBRSHA $DIRTY )
 			else
@@ -340,22 +340,22 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 
 				ut0 Commit away from the tag
 				_git_add_commit newfile
-				ut "git_version --dirty" == "1.1-1-g$(git rev-parse --short=10 HEAD)"
+				ut "git_version --dirty" == "1.1-1-g$(git rev-parse --short=7 HEAD)"
 
 				ut0 Commit away from the tag
 				_git_add_commit newfile2
-				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=10 HEAD)"
+				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=7 HEAD)"
 
 				ut0 Away w. non-conforming ann. tag
 				git tag -a w.2015.34 -m "Weekly 2015.34"
-				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=10 HEAD)"
+				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=7 HEAD)"
 
 				ut0 Away w. non-conforming ann. tag on cmdline
-				ut "git_version w.2015.34" == "1.1-2-g$(git rev-parse --short=10 HEAD)"
+				ut "git_version w.2015.34" == "1.1-2-g$(git rev-parse --short=7 HEAD)"
 
 				ut0 Dirty commit away from the tag
 				echo "stuff" >> newfile2
-				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=10 HEAD)-dirty"
+				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=7 HEAD)-dirty"
 				git reset --hard -q
 
 
@@ -374,7 +374,7 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 				ut0 Where --first-parent makes a difference
 				git checkout -q master > /dev/null
 				git merge next2 -m "Merge" > /dev/null
-				ut "git_version --dirty" == "1.1-3-g$(git rev-parse --short=10 HEAD)"
+				ut "git_version --dirty" == "1.1-3-g$(git rev-parse --short=7 HEAD)"
 
 				#git log --decorate --oneline --graph --all
 				#git describe

--- a/bin/pkgautoversion
+++ b/bin/pkgautoversion
@@ -159,7 +159,7 @@ git_version()
 			# Commit is not on any branch (orphaned)
 			RES=($ABBRSHA $DIRTY)
 		elif [[ $BRANCH = master ]]; then
-			local DESC=$(git describe --first-parent --match "$TAG_PATTERN" 2>/dev/null)
+			local DESC=$(git describe --abbrev=10 --first-parent --match "$TAG_PATTERN" 2>/dev/null)
 			if [[ -z $DESC ]]; then
 				RES=($BRANCH g$ABBRSHA $DIRTY )
 			else

--- a/bin/pkgautoversion
+++ b/bin/pkgautoversion
@@ -309,10 +309,20 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 				git tag 1.0
 				ut "git_version --dirty" == "master-g$(git rev-parse --short=10 HEAD)"
 
+				ut0 Non-conforming annotated tag
+				git tag -a w.2015.33 -m "Weekly 2015.33"
+				ut "git_version --dirty" == "master-g$(git rev-parse --short=10 HEAD)"
+
+				ut0 Non-conforming annotated tag, on cmdline
+				ut "git_version w.2015.33" == "w.2015.33"
+
 				ut0 Annotated and non-annotated tags on HEAD
 				git tag -a 2.0 -m "Version 2.0"
 				ut "git_version --dirty" == "2.0"
 				
+				ut0 Non-conforming annotated tag, on cmdline
+				ut "git_version w.2015.33" == "w.2015.33"
+
 				ut0 Added lower version tag on the same commit
 				git tag -a 1.1 -m "Version 1.1"
 				ut "git_version --dirty" == "1.1"
@@ -335,6 +345,13 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 				ut0 Commit away from the tag
 				_git_add_commit newfile2
 				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=10 HEAD)"
+
+				ut0 Away w. non-conforming ann. tag
+				git tag -a w.2015.34 -m "Weekly 2015.34"
+				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=10 HEAD)"
+
+				ut0 Away w. non-conforming ann. tag on cmdline
+				ut "git_version w.2015.34" == "w.2015.34"
 
 				ut0 Dirty commit away from the tag
 				echo "stuff" >> newfile2

--- a/bin/pkgautoversion
+++ b/bin/pkgautoversion
@@ -8,9 +8,11 @@ usage()
 		usage: $(basename $0) [--dirty] [ref=HEAD] [tag_pattern='[0-9]*']
 
 		Applies the following logic:
-		  * If ref is a tag, returns the ref
-		  * Otherwise, return an annotated tag attached to ref
+		  * If ref is a conforming annotated tag (see below), returns the ref
+		  * Otherwise, returns a conforming annotated tag attached to the ref
 		  * Otherwise, returns [branch-g]<sha1>[-dirty]
+
+		A conforming tag is one that matches <tag_pattern>.
 
 		If multiple tags are elegible to describe the ref, uses the
 		one that's the lowest when compared per-component (i.e.,
@@ -129,15 +131,13 @@ git_version()
 	fi
 
 	local REF=${1:-HEAD}
+	local TAG_PATTERN=${2:-'[0-9]*'}	# The pattern defining eligible tags
 
-	# Check if this ref is already an annotated tag; if yes, we're done.
-	if [[ $(git cat-file -t "$REF" 2>/dev/null) == tag ]]; then
+	# Check if this ref is already an annotated tag matching the tag pattern; if yes, we're done.
+	if [[ "$REF" == $TAG_PATTERN && $(git cat-file -t "$REF" 2>/dev/null) == tag ]]; then
 		_eups_compat_version "$REF"
 		return
 	fi
-
-	# Get pattern defining eligible tags
-	local TAG_PATTERN=${2:-'[0-9]*'}
 
 	# See if any annotated tags matching TAG_PATTERN point to $REF. If yes,
 	# find the tag with the lowest version number (when versions are
@@ -314,14 +314,14 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 				ut "git_version --dirty" == "master-g$(git rev-parse --short=10 HEAD)"
 
 				ut0 Non-conforming annotated tag, on cmdline
-				ut "git_version w.2015.33" == "w.2015.33"
+				ut "git_version w.2015.33" == "master-g$(git rev-parse --short=10 HEAD)"
 
 				ut0 Annotated and non-annotated tags on HEAD
 				git tag -a 2.0 -m "Version 2.0"
 				ut "git_version --dirty" == "2.0"
 				
 				ut0 Non-conforming annotated tag, on cmdline
-				ut "git_version w.2015.33" == "w.2015.33"
+				ut "git_version w.2015.33" == "2.0"
 
 				ut0 Added lower version tag on the same commit
 				git tag -a 1.1 -m "Version 1.1"
@@ -351,7 +351,7 @@ if [[ "$RUN_UNIT" == 1 ]]; then
 				ut "git_version --dirty" == "1.1-2-g$(git rev-parse --short=10 HEAD)"
 
 				ut0 Away w. non-conforming ann. tag on cmdline
-				ut "git_version w.2015.34" == "w.2015.34"
+				ut "git_version w.2015.34" == "1.1-2-g$(git rev-parse --short=10 HEAD)"
 
 				ut0 Dirty commit away from the tag
 				echo "stuff" >> newfile2


### PR DESCRIPTION
`bin/pkgautoversion` is the utility that tries to compute a reasonably-looking version from the git information. It can take an argument -- `REF` -- that it may use as a hint when it's constructing a version (e.g., if there are no annotated tags defined at all, then it will construct the version of the form `<REF>-g<SHA1>`).

Before this PR, `pkgautoversion` would check if `REF` was an annotated tag. If it was, it would return `REF` as the version. This worked as expected, as long as one followed a convention to use annotated tags for (numerical) version only (e.g., `10.1`, `10.1.2`, etc.).

The introduction of weekly tags of the form of `w.2015.33`, etc, changed the convention. That lead to many packages having a version such as `w.2015.33`, if the stack was built with `lsstsw` using a command line such as:
```
rebuild -r w.2015.33 -r 2.0.1 lsst_sims
```
(which is what the simulations team is using to generate builds based off a DM weekly).

Such arbitrary versions are generally hard to parse (and order) -- causing problems for `conda` binary packaging and updating. It also leads to rebuilds of packages that have already been built (because though they have the same SHA1, `lsstsw` sees them with a different version). It can also mask the true version of a package -- esp. nasty with 3rd party packages (e.g., `fftw`).

Because of this, this PR changes the behavior to immediately return the tag *only* if it matches the TAG_PATTERN (which is currently defined as `[0-9]*`, but could be tightened further in the future). Otherwise, the version will be computed using the fall-back rules, as if the tag wasn't there.

Here are some before/after versions, to get a feel for the impacts of this change:
```
before: fftw                      8fdba61333025ecee68de6da9c770be41cdb547e  w.2015.33
after:  fftw                      8fdba61333025ecee68de6da9c770be41cdb547e  3.3.3-1-g8fdba61
```
```
before: afw                       f63c96a08c1dbfb65ce2f5fb23e5c986450f32b3  w.2015.33
after:  afw                       f63c96a08c1dbfb65ce2f5fb23e5c986450f32b3  10.1-38-gf63c96a
```

For more see [before](https://s3.amazonaws.com/uploads.hipchat.com/100518/737581/s0HFNB11qbg3NEz/manifest.before.txt) and [after](https://s3.amazonaws.com/uploads.hipchat.com/100518/737581/F0qyJ2I3uy1jgGM/manifest.txt) `lsstsw` manifest files.

W/o this change, it's very difficult to build `conda` packages (and other packaging system that care about the ordering of versions are likely to have similar problems).