### PR TITLE
Spaces in path

### DIFF
--- a/bin/eups.in
+++ b/bin/eups.in
@@ -3,4 +3,4 @@
 #  #!/usr/bin/env python options
 #
 unset PYTHONSTARTUP
-@EUPS_PYTHON@ -S $EUPS_DIR/bin/eups_impl.py "$@"
+@EUPS_PYTHON@ -S "$EUPS_DIR/bin/eups_impl.py" "$@"

--- a/bin/eups_setup.in
+++ b/bin/eups_setup.in
@@ -3,4 +3,4 @@
 #  #!/usr/bin/env python options
 #
 unset PYTHONSTARTUP
-@EUPS_PYTHON@ -S $EUPS_DIR/bin/eups_setup_impl.py "$@"
+@EUPS_PYTHON@ -S "$EUPS_DIR/bin/eups_setup_impl.py" "$@"

--- a/bin/eupspkg
+++ b/bin/eupspkg
@@ -12,4 +12,4 @@ if [[ ! -d ./ups && "$1" != "-h" ]]; then
 	exit -1
 fi
 
-exec $EUPS_DIR/lib/eupspkg.sh "$@"
+exec "$EUPS_DIR/lib/eupspkg.sh" "$@"

--- a/bin/mksetup
+++ b/bin/mksetup
@@ -59,7 +59,7 @@ if ("$?EUPS_DIR" == "1" ) then
    endif
    setenv EUPS_DIR "${EUPS_DIR}"
 else
-   setenv EUPS_DIR %(eupsdir)s
+   setenv EUPS_DIR "%(eupsdir)s"
 endif
 
 if ("$?EUPS_PATH" == "0" ) then
@@ -77,15 +77,15 @@ setenv SETUP_EUPS "eups"
 unsetenv PROD_DIR_PREFIX
 unsetenv PRODUCTS
 
-setenv PATH ${PATH}:%(bindir)s
+setenv PATH "${PATH}:%(bindir)s"
 if ("$?PYTHONPATH" == "1" ) then
-   setenv PYTHONPATH ${PYTHONPATH}:%(pythondir)s
+   setenv PYTHONPATH "${PYTHONPATH}:%(pythondir)s"
 else
-   setenv PYTHONPATH %(pythondir)s
+   setenv PYTHONPATH "%(pythondir)s"
 endif
 
-alias setup 'eval `%(setup)s \\!*`'
-alias unsetup 'eval `%(setup)s --unsetup \\!*`'
+alias setup 'eval `"%(setup)s" \\!*`'
+alias unsetup 'eval `"%(setup)s" --unsetup \\!*`'
 
 """ % {"bindir" : bindir, "eupsdir" : eupsdir, "prefix" : prefix, \
            "pythondir" : pythondir, "setup" : setup,  "unique_eups_path" : unique_eups_path }
@@ -110,7 +110,7 @@ if [ "$EUPS_DIR" != "" ]; then
    PYTHONPATH=`echo $PYTHONPATH | perl -pe "s|:%(pythondir)s||g"`
    export EUPS_DIR
 else
-   export EUPS_DIR=%(eupsdir)s
+   export EUPS_DIR="%(eupsdir)s"
 fi
 
 # Set EUPS_PATH, appending any pre-existing EUPS_PATH (and only keeping
@@ -129,8 +129,8 @@ else
     export PYTHONPATH="%(pythondir)s"
 fi
 
-setup()   { eval `%(setup)s           "$@"`; }
-unsetup() { eval `%(setup)s --unsetup "$@"`; }
+setup()   { eval `"%(setup)s"           "$@"`; }
+unsetup() { eval `"%(setup)s" --unsetup "$@"`; }
 
 if [ X$BASH_COMPLETION != X -a -f "$EUPS_DIR/etc/bash_completion.d/eups" ]; then
     source "$EUPS_DIR/etc/bash_completion.d/eups"

--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -755,7 +755,7 @@ The what argument tells us what sort of state is expected (allowed values are de
             args.pop(0);  flavor = args.pop(0)
 
         if len(args) > 1 and (args[0] == "-Z" or args[0] == "-z"):
-            args.pop(0);  eupsPathDir = args.pop(0)
+            args.pop(0);  eupsPathDir = utils.decodePath(args.pop(0))
 
         if len(args) > 1 and (args[0] == "-m"):
             args.pop(0);  tablefile = args.pop(0)
@@ -2047,7 +2047,7 @@ The what argument tells us what sort of state is expected (allowed values are de
                 version = product.version
 
             setup_product_str = "%s %s -f %s -Z %s" % (
-                product.name, version, setupFlavor, product.stackRoot())
+                product.name, version, setupFlavor, utils.encodePath(product.stackRoot()))
             if tablefile:
                 setup_product_str += " -m %s" % (tablefile)
 

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -314,6 +314,18 @@ def guessProduct(dir, productName=None):
         raise RuntimeError, \
               ("I can't guess which product you want; directory %s contains: %s" % (dir, " ".join(productNames)))
 
+SPACE_TO_STRING = "-+-"
+def encodePath(path):
+    """Encode a directory path such that it is suitable for inclusion in an EUPS
+    environment variable. This currently means that spaces are encoded. Use decodePath()
+    to reverse this process.
+    """
+    return path.replace(" ", SPACE_TO_STRING)
+
+def decodePath(encodedPath):
+    """Decode a directory path that was encoded by encodePath()."""
+    return encodedPath.replace(SPACE_TO_STRING, " ")
+
 class Flavor(object):
     """A class to handle flavors"""
 


### PR DESCRIPTION
These changes allow EUPS_DIR and EUPS_PATH to include spaces.

* Add quoting to shell scripts.
* Encoding and decoding of paths when stored in internal EUPS environment variables:
   * The `SETUP_*` variable needs to store the stack location.
   * A local setup stores the path to the setup directory in the version string.

There may be more changes required but these allowed me to run EUPS and build a stack on en external drive on my Mac that has spaces in the name.