### PR TITLE
add https support to eups.distrib.server.WebTransporter

### DIFF
--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -944,6 +944,7 @@ class WebTransporter(Transporter):
         """return True if this source location is recognized as one that 
         can be handled by this Transporter class"""
         return bool(re.search(r'^http://', source)) or \
+               bool(re.search(r'^https://', source)) or \
                bool(re.search(r'^ftp://', source)) 
 
     canHandle = staticmethod(canHandle)  # should work as of python 2.2


### PR DESCRIPTION
Resolves this error message when setting `EUPS_PKGROOT` to a HTTPS URL.

    eups distrib: Transport for file not recognized: ...