### PR TITLE
Test errors in testTable and testStack

### DIFF
--- a/python/eups/Product.py
+++ b/python/eups/Product.py
@@ -1,7 +1,10 @@
 # from Table import *
 from __future__ import absolute_import, print_function
 import os, re, sys
-import pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 try:
     from configparser import ConfigParser
 except ImportError:

--- a/python/eups/app.py
+++ b/python/eups/app.py
@@ -4,7 +4,10 @@ common high-level EUPS functions appropriate for calling from an application.
 
 from __future__ import absolute_import, print_function
 import re, os, sys, time
-import pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from .Eups           import Eups
 from .exceptions     import ProductNotFound
 from .tags           import Tags, Tag, TagNotRecognized, checkTagsList

--- a/python/eups/stack/ProductStack.py
+++ b/python/eups/stack/ProductStack.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import, print_function
-import re, os, pickle, sys
+import re, os, sys
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from eups import utils
 from eups import Product
 from .ProductFamily import ProductFamily

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -454,7 +454,10 @@ def canPickle():
     cache product info.
     """
     try:
-        import pickle
+        try:
+            import cPickle as pickle
+        except ImportError:
+            import pickle
         pickle.dump(None, None, protocol=2)
     except (TypeError, ImportError, AttributeError):
         return False

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -456,9 +456,7 @@ def canPickle():
     try:
         import pickle
         pickle.dump(None, None, protocol=2)
-    except TypeError:
-        return False
-    except ImportError:
+    except (TypeError, ImportError, AttributeError):
         return False
 
     return True


### PR DESCRIPTION
This change fixes some test errors in `testTable` and `testStack` using python 2.7.11 where `pickle.dump(None, None, protocol=2)` gives an `AttributeError`. I have also continued to use the C implementation of pickle where it was used in 1.5.10 and falling back to pickle in python 3 or where the C implementation is not available.