### PR TITLE
Fix tests broken by py3 updates

### DIFF
--- a/python/eups/tags.py
+++ b/python/eups/tags.py
@@ -146,7 +146,7 @@ class Tags(object):
         if group is None:
             group = self.global_
 
-        if isinstance(name, basestring):
+        if isinstance(name, str):
             owner = None
         else:
             name, owner = name

--- a/tests/testApp.py
+++ b/tests/testApp.py
@@ -10,7 +10,7 @@ import sys
 import shutil
 import unittest
 import time
-from io import StringIO
+from eups.utils import StringIO
 import testCommon
 from testCommon import testEupsStack
 

--- a/tests/testCmd.py
+++ b/tests/testCmd.py
@@ -8,7 +8,7 @@ import sys
 import unittest
 import time
 import re, shutil
-import io as StringIO
+from eups.utils import StringIO
 import testCommon
 from testCommon import testEupsStack
 

--- a/tests/testDeprecated.py
+++ b/tests/testDeprecated.py
@@ -10,11 +10,11 @@ import time
 import unittest
 import testCommon
 from testCommon import testEupsStack
-from io import StringIO
+from eups.utils import StringIO
 
 # reroute the error stream defined in eups.util to newerr
 syserr = sys.stderr
-newerr = StringIO()
+newerr = StringIO.StringIO()
 sys.stderr = newerr
 import eups.utils
 reload(eups.utils)

--- a/tests/testEups.py
+++ b/tests/testEups.py
@@ -9,7 +9,7 @@ import sys
 import shutil
 import unittest
 import time
-from io import StringIO
+from eups.utils import StringIO
 import testCommon
 from testCommon import testEupsStack
 
@@ -373,7 +373,7 @@ class EupsTestCase(unittest.TestCase):
     def testDeclareStdinTable(self):
         pdir = os.path.join(testEupsStack, "Linux", "newprod")
         pdir11 = os.path.join(pdir, "1.1")
-        tableStrm = StringIO('setupRequired("python")\n')
+        tableStrm = StringIO.StringIO('setupRequired("python")\n')
         prod = self.eups.findProduct("newprod", "1.1")
         self.assert_(prod is None, "newprod is already declared")
 


### PR DESCRIPTION
The new failures were due to the replacement of `cStringIO.StringIO` with `io.StringIO` -- in Python 2.7, the former expects `str`, while the latter expects `unicode`. I've fixed it by importing `cStringIO` in 2 and `io` in 3. Should fix #55 (I now reproduce the same failures as before the py3 compatibility patchset :) ).

@migueldvb, could you test if it breaks Python 3 compatibility?