### PR TITLE
Fix much of issue 72

### DIFF
--- a/python/eups/db/ChainFile.py
+++ b/python/eups/db/ChainFile.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
-import os, re, sys, errno
-from eups.utils import ctimeTZ, isRealFilename, stdwarn, stderr, getUserName
+import os
+import re
+import errno
+from eups.utils import ctimeTZ, stdwarn, getUserName
 
 who = getUserName(full=True)
 

--- a/python/eups/db/Database.py
+++ b/python/eups/db/Database.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import
 
-import os, sys, re
+import os
+import re
 from .VersionFile import VersionFile
 from .ChainFile import ChainFile
-from eups.utils import isRealFilename, isDbWritable
 import eups.tags
 from eups.Product import Product
 from eups.exceptions import UnderSpecifiedProduct, ProductNotFound
-from eups.exceptions import TableError
 
 versionFileExt = "version"
 versionFileTmpl = "%s." + versionFileExt

--- a/python/eups/db/Database.py
+++ b/python/eups/db/Database.py
@@ -6,7 +6,7 @@ from .VersionFile import VersionFile
 from .ChainFile import ChainFile
 import eups.tags
 from eups.Product import Product
-from eups.exceptions import UnderSpecifiedProduct, ProductNotFound
+from eups.exceptions import UnderSpecifiedProduct, ProductNotFound, TableFileNotFound
 
 versionFileExt = "version"
 versionFileTmpl = "%s." + versionFileExt
@@ -407,7 +407,6 @@ class _Database(object):
             for file in vfiles:
                 if (versionFileRe.match(file)):
                     file = VersionFile(os.path.join(pdir,file))
-                    vers = file.version
                     if file.hasFlavor(flavor):
                         return True
 

--- a/python/eups/db/VersionFile.py
+++ b/python/eups/db/VersionFile.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import os, re, sys
+import os
+import re
 from eups.Product import Product
 from eups.exceptions import ProductNotFound
 from eups.utils import ctimeTZ, isRealFilename

--- a/python/eups/distrib/Distrib.py
+++ b/python/eups/distrib/Distrib.py
@@ -11,10 +11,9 @@ import re
 import eups
 import eups.hooks as hooks
 import eups.table
-from . import server
-from .server import RemoteFileNotFound, Manifest, TaggedProductList
 from eups.VersionParser import VersionParser
 from eups.exceptions import EupsException
+from . import server
 
 class Distrib(object):
     """A class to encapsulate product distribution
@@ -281,7 +280,7 @@ class Distrib(object):
         @param  flavor         the target platform for the release (default: 
                                  "generic")
         """
-        release = TaggedProductList(tag, flavor, self.verbose-1, sys.log)
+        release = server.TaggedProductList(tag, flavor, self.verbose-1, sys.log)
         self._recurseProdDeps(release, top_product, top_version, flavor)
 
 
@@ -376,7 +375,7 @@ class Distrib(object):
         """
         if flavor is None:  flavor = self.flavor
         if tag is None:  tag = self.tag
-        productList = Manifest(productName, versionName, self.Eups, self.verbose-1,
+        productList = server.Manifest(productName, versionName, self.Eups, self.verbose-1,
                                log=self.log)
 
         # add a record for the top product
@@ -395,7 +394,7 @@ class Distrib(object):
                 if not tablefile and self.distServer:
                     try:
                         tablefile = self.distServer.getTableFile(product, version, self.flavor)
-                    except RemoteFileNotFound:
+                    except server.RemoteFileNotFound:
                         pass
                 return tablefile
 
@@ -671,7 +670,7 @@ class DefaultDistrib(Distrib):
                 print(msg, file=self.log)
             return None
 
-        return TaggedProductList.fromFile(file, tag)
+        return server.TaggedProductList.fromFile(file, tag)
 
     def getTaggedReleasePath(self, tag, flavor=None):
         """get the file path relative to a server root that will be used 
@@ -688,7 +687,7 @@ class DefaultDistrib(Distrib):
         @param serverDir      a local directory representing the root of the 
                                   package distribution tree
         @param tag            the name to give to the release
-        @param products       a TaggedProductList instance containing the list
+        @param products       a server.TaggedProductList instance containing the list
                                   of products in the release
         @param flavor         the target flavor for this release.  An 
                                   implementation may ignore this variable.  
@@ -765,7 +764,7 @@ class DefaultDistrib(Distrib):
         if not os.path.exists(mandir):
 	        os.makedirs(mandir)
 
-        man = Manifest(product, version, self.Eups, 
+        man = server.Manifest(product, version, self.Eups, 
                        verbosity=self.verbose-1, log=self.log)
         for dep in productDeps:
             man.addDepInst(dep)

--- a/python/eups/distrib/Distrib.py
+++ b/python/eups/distrib/Distrib.py
@@ -602,7 +602,7 @@ class Distrib(object):
                                   self.log)
                 except OSError:  pass
             try:
-                system("chmod %sg+rws%s %s" % (recurse, change, dir), 
+                server.system("chmod %sg+rws%s %s" % (recurse, change, dir), 
                        self.Eups.noaction, self.verbose-2, self.log)
             except OSError:  pass
 

--- a/python/eups/distrib/Distrib.py
+++ b/python/eups/distrib/Distrib.py
@@ -5,7 +5,9 @@
 # product from a package
 #
 from __future__ import absolute_import, print_function
-import sys, os, re, atexit, shutil
+import sys
+import os
+import re
 import eups
 import eups.hooks as hooks
 import eups.table
@@ -393,7 +395,7 @@ class Distrib(object):
                 if not tablefile and self.distServer:
                     try:
                         tablefile = self.distServer.getTableFile(product, version, self.flavor)
-                    except RemoteFileNotFound as e:
+                    except RemoteFileNotFound:
                         pass
                 return tablefile
 
@@ -881,7 +883,7 @@ class DefaultDistrib(Distrib):
                 except KeyboardInterrupt:
                     raise RuntimeError("You hit ^C while looking for %s %s's table file" %
                                          (product, version))
-                except eups.ProductNotFound as e:
+                except eups.ProductNotFound:
                     return self.findTableFile(prod.product, prod.version, prod.flavor)
                 except Exception:
                     return None

--- a/python/eups/distrib/DistribFactory.py
+++ b/python/eups/distrib/DistribFactory.py
@@ -5,8 +5,9 @@
 # product from a package: a specialization for Pacman
 #
 from __future__ import absolute_import
-import sys, os, re, copy
-import eups
+import sys
+import re
+import copy
 from . import server as eupsServer
 
 from .Distrib import Distrib

--- a/python/eups/distrib/Repositories.py
+++ b/python/eups/distrib/Repositories.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, print_function
 import sys
 import os
 import re
+import traceback
 
 import eups.utils as utils
 from . import server
@@ -214,7 +215,7 @@ class Repositories(object):
         versions = [version]
         if version and isinstance(version, Tag):
             if not version.isGlobal():
-                raise TagNotRecognized(tag.name, "global", 
+                raise TagNotRecognized(version.name, "global", 
                                        msg="Non-global tag %s requested." % 
                                            version.name)
         if not version:
@@ -718,23 +719,20 @@ class Repositories(object):
     def _readDistIDFile(self, file):
         distId = None
         pkgroot = None
-        idf = open(file)
-        try:
-          try:
-            while line in idf:
-                line = line.strip()
-                if len(line) > 0:
-                    if not distId:
-                        distId = line
-                    elif not pkgroot:
-                        pkgroot = line
-                    else:
-                        break
-          finally:
-            idf.close()
-        except Exception:
-            if self.verbose >= 0:
-                print("Warning: trouble reading %s, skipping" % file, file=self.log)
+        with open(file) as idf:
+            try:
+                for line in idf:
+                    line = line.strip()
+                    if len(line) > 0:
+                        if not distId:
+                            distId = line
+                        elif not pkgroot:
+                            pkgroot = line
+                        else:
+                            break
+            except Exception:
+                if self.verbose >= 0:
+                    print("Warning: trouble reading %s, skipping" % file, file=self.log)
 
         return (distId, pkgroot)
             

--- a/python/eups/distrib/Repositories.py
+++ b/python/eups/distrib/Repositories.py
@@ -3,18 +3,19 @@ the Repositories class -- a set of distribution servers from which
 distribution packages can be received and installed.
 """
 from __future__ import absolute_import, print_function
-import sys, os, re, atexit, shutil
+import sys
+import os
+import re
 
 import eups.utils as utils
 from . import server
-from eups           import Eups, Tag, Tags, TagNotRecognized
+from eups           import Eups, Tag, TagNotRecognized
 from eups           import ProductNotFound, EupsException
 from .Repository     import Repository 
-from eups.utils     import Flavor, Quiet
+from eups.utils     import Flavor
 from .Distrib        import findInstallableRoot
 from .DistribFactory import DistribFactory
-from .server         import ServerConf, Manifest, ServerError
-from . import server
+from .server         import Manifest, ServerError
 import eups.hooks as hooks
 
 class Repositories(object):
@@ -731,7 +732,7 @@ class Repositories(object):
                         break
           finally:
             idf.close()
-        except Exception as e:
+        except Exception:
             if self.verbose >= 0:
                 print("Warning: trouble reading %s, skipping" % file, file=self.log)
 
@@ -873,11 +874,11 @@ class Repositories(object):
                 rmCmd = "rm -rf %s" % buildDir
                 try:
                     server.system(rmCmd, verbosity=-1, log=self.log)
-                except OSError as e:
+                except OSError:
                     rmCmd = r"find %s -exec chmod 775 {} \; && %s" % (buildDir, rmCmd)
                     try:
                         server.system(rmCmd, verbosity=self.verbose-1, log=self.log)
-                    except OSError as e:
+                    except OSError:
                         print("Error removing %s; Continuing" % (buildDir), file=self.log)
 
             elif self.verbose > 0:
@@ -964,7 +965,7 @@ class Repositories(object):
                     if utils.isDbWritable(installDir):
                         try:
                             server.system("/bin/rm -rf %s" % installDir)
-                        except OSError as e:
+                        except OSError:
                             print("Error removing %s; Continuing" % (installDir), file=self.log)
 
                     elif self.verbose >= 0:

--- a/python/eups/distrib/Repository.py
+++ b/python/eups/distrib/Repository.py
@@ -7,6 +7,7 @@ import sys
 import eups
 from eups.tags      import Tag, TagNotRecognized
 from eups.utils     import Flavor, isDbWritable
+from eups.exceptions import EupsException, ProductNotFound
 from .server         import ServerConf, Manifest, Mapping, TaggedProductList
 from .server         import LocalTransporter
 from .DistribFactory import DistribFactory
@@ -582,7 +583,8 @@ class Repository(object):
                                                  self.options, self.verbose-2,
                                                  self.log)
         flavor = dp.flavor
-        if flavor == generic:  flavor = None
+        if flavor == "generic":
+            flavor = None
         return distrib.packageCreated(self.pkgroot, dp.product, dp.version, flavor)
 
     def createTaggedRelease(self, tag, product, version=None, flavor=None, 

--- a/python/eups/distrib/Repository.py
+++ b/python/eups/distrib/Repository.py
@@ -3,15 +3,14 @@ the Repository class -- An interface into a distribution server for
 installing and deploying distribution packages.
 """
 from __future__ import absolute_import, print_function
-import sys, os, re, atexit, shutil
+import sys
 import eups
-from . import server 
 from eups.tags      import Tag, TagNotRecognized
-from eups.utils     import Flavor, Quiet, isDbWritable
+from eups.utils     import Flavor, isDbWritable
 from .server         import ServerConf, Manifest, Mapping, TaggedProductList
-from .server         import RemoteFileNotFound, LocalTransporter
+from .server         import LocalTransporter
 from .DistribFactory import DistribFactory
-from .Distrib        import Distrib, DefaultDistrib, findInstallableRoot
+from .Distrib        import Distrib, DefaultDistrib
 
 class Repository(object):
     """

--- a/python/eups/distrib/builder.py
+++ b/python/eups/distrib/builder.py
@@ -5,8 +5,8 @@
 # product from a package: a specialization for the "Builder" mechanism
 #
 from __future__ import absolute_import, print_function
-import sys, os, re, shutil
-import eups
+import sys
+import os, re
 from . import Distrib as eupsDistrib
 from . import server as eupsServer
 import eups.hooks

--- a/python/eups/distrib/builder.py
+++ b/python/eups/distrib/builder.py
@@ -594,10 +594,10 @@ def expandBuildFile(ofd, ifd, productName, versionName, verbose=False, builderVa
             repoVersion = eups.hooks.config.Eups.repoVersioner(productName, versionName)
         except Exception as e:
             raise RuntimeError("Unable to call hooks.Eups.config.repoVersioner for %s %s (%s)" % 
-                               (productName, inVersion, e))
+                               (productName, versionName, e))
 
         if repoVersion is None:
-            repoVersion = inVersion
+            repoVersion = versionName
 
         #print "Repository version name for %s: %s --> %s" % (productName, versionName, repoVersion)
 
@@ -670,8 +670,6 @@ def expandBuildFile(ofd, ifd, productName, versionName, verbose=False, builderVa
     #
     # Actually do the work
     #
-    versionNameRe = re.escape(versionName)
-
     for line in ifd:
         line = line.rstrip()
 

--- a/python/eups/distrib/eupspkg.py
+++ b/python/eups/distrib/eupspkg.py
@@ -671,11 +671,9 @@ r"""
 """
 
 from __future__ import absolute_import, print_function
-import sys, os, shutil, tarfile, tempfile, pipes, stat
-import eups
+import sys, os, shutil, tempfile, pipes, stat
 from . import Distrib as eupsDistrib
 from . import server as eupsServer
-import eups.hooks
 
 
 class Distrib(eupsDistrib.DefaultDistrib):

--- a/python/eups/distrib/pacman.py
+++ b/python/eups/distrib/pacman.py
@@ -5,8 +5,7 @@
 # product from a package: a specialization for Pacman
 #
 from __future__ import print_function
-import sys, os, re, atexit, shutil
-import eups
+import sys, os
 from . import Distrib as eupsDistrib
 from . import server as eupsServer
 
@@ -197,7 +196,7 @@ class Distrib(eupsDistrib.DefaultDistrib):
             eupsServer.system("""cd %s && pacman -allow urllib2 -install "%s" """ % \
                                   (pacmanDir, location), 
                               self.Eups.noaction, self.verbose, self.log)
-        except OSError as e:
+        except OSError:
             raise RuntimeError("Pacman failed to install " + location)
 
     def createPacmanDir(self, pacmanDir):

--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -1330,7 +1330,7 @@ class TaggedProductList(object):
                             be merged.
         """
         for p in products.getProducts():
-            addProduct(p[0], p[2], p[1], p[3:])
+            self.addProduct(p[0], p[2], p[1], p[3:])
 
     def read(self, filename):
         """read the products from a given file and add it to our list.  
@@ -1714,7 +1714,6 @@ class Manifest(object):
 
         FALSE = "FALSE"
         TRUE = "TRUE"
-        REQ = "REQUIRED"
         OPT = "OPTIONAL"
         for line in fd:
             line = line.split("\n")[0]
@@ -1935,7 +1934,6 @@ Additional mappings can be provided.
 
             mat = re.search(r"^\s*verbose\s*=\s*(True|False|0|1)\s*", line)
             if mat:
-                verboseMapping = bool(mat.group(1))
                 continue
 
             vals = line.split()

--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -1546,7 +1546,7 @@ class Mapping(object):
         if not len(self._mapping[flavor][inProduct]):
             # Indicate product should be removed completely
             return inProduct, None
-        for versName in (inVersion, "any") or fnmatch.fnmatch(inVersion, versName):
+        for versName in (inVersion, "any"):
             if versName in self._mapping[flavor][inProduct]:
                 return self._mapping[flavor][inProduct][versName]
         # No mapping for this version
@@ -1837,7 +1837,10 @@ The mapping is defined by the file userDataDir/manifest.remap, which consists of
 productName[:version-in-manifest]    [[outProductName:]desired-version]    [flavor]
 
 Comments (starting with #) are skipped
-If version-in-manifest is "Any" or a matching glob (e.g. "*") the desired-version is used for all products
+If version-in-manifest is "Any" the desired-version is used for all products
+(Note: it was intended to also support glob expressions, but that has yet to be done;
+see the discussion of fnmatch in https://github.com/RobertLuptonTheGood/eups/issues/72
+for more details.)
 If oproductName is present, productName is replaced by outProductName
 If desired-version is "None" or omitted, the product is deleted from the Manifest.
 If flavor is supplied, the mapping is only applied for that flavor

--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -488,7 +488,7 @@ class ConfigurableDistribServer(DistribServer):
 
         # check for unrecognized keys in config files
         for k in self.config.keys():
-            if not (k in self.validConfigKeys):
+            if k not in self.validConfigKeys:
                 print("Invalid config parameter %s ignored" % k, file=self.log)
 
         if 'MANIFEST_URL' not in self.config:

--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -4,7 +4,10 @@
 classes for communicating with a remote package server
 """
 from __future__ import print_function
-import sys, os, re, atexit, shutil
+import sys
+import os
+import re
+import atexit
 import fnmatch
 import tempfile
 try:
@@ -2059,7 +2062,7 @@ class ServerConf(object):
 
                 self.data = self.readConfFile(configFile);
 
-        except RemoteFileNotFound as e:
+        except RemoteFileNotFound:
             if self.base != "/dev/null" and self.verbose > 0:
                 print("Warning: No configuration available from server;", \
                     'assuming "vanilla" server', file=self.log)

--- a/python/eups/distrib/tarball.py
+++ b/python/eups/distrib/tarball.py
@@ -185,7 +185,7 @@ DIST_URL = %(base)s/%(path)s
         """
         tarball = location
         if not tarball:
-            raise RuntimeError("Expected a tarball name; saw \"%s\"" % distID)
+            raise RuntimeError("Expected a tarball name; saw \"%s\"" % location)
 
         if not buildDir:
             buildDir = self.getOption('buildDir', 'EupsBuildDir')

--- a/python/eups/distrib/tarball.py
+++ b/python/eups/distrib/tarball.py
@@ -6,7 +6,6 @@
 #
 from __future__ import absolute_import, print_function
 import sys, os, re
-import eups
 from . import Distrib as eupsDistrib
 from . import server as eupsServer
 


### PR DESCRIPTION
This pull request goes a long way to fixing issue https://github.com/RobertLuptonTheGood/eups/issues/72. It cleans up the db and distrib sub-packages of eups, including fixing a half dozen or so errors involving undefined variables.

It leaves one important bug unfixed:

server.py has the following incorrect bit of code:

        for versName in (inVersion, "any") or fnmatch.fnmatch(inVersion, versName):
            if versName in self._mapping[flavor][inProduct]:

Without the `or fnmatch...` it makes sense. I have no idea what the bit involving the fnmatch is trying to do, so I don't know how to fix this. I have emailed several people, including Paul Price (who is credited with having been the last to edit the first of these lines).

Note: I suggest doing all of the following before merging this branch:
- Fix issue #66 (e.g. using my branch)
- Test eups distrib and db
- Rebase this branch to master