### PR TITLE
Fix75

### DIFF
--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -2365,7 +2365,7 @@ The what argument tells us what sort of state is expected (allowed values are de
                 eupsPathDir = None
         else:                           # look for proper home on self.path
             for d in self.path:
-                if utils.commonpath([productDir, d]) == d:
+                if utils.isSubpath(d, productDir):
                     eupsPathDir = d
                     eupsPathDirForRead = d
                     break
@@ -2446,7 +2446,7 @@ The what argument tells us what sort of state is expected (allowed values are de
 
                 externalFileList.append((full_tablefile, os.path.join("ups", "%s.table" % productName)))
             elif os.path.isabs(tablefile): # maybe we're redeclaring an interned filesystem?
-                if utils.commonpath([dbpath, tablefile]) == dbpath:
+                if utils.isSubpath(tablefile, dbpath):
                     ups_dir = os.path.join("$UPS_DB",
                                            utils.extraDirPath(self.flavor, productName, versionName), "ups")
 

--- a/python/eups/db/VersionFile.py
+++ b/python/eups/db/VersionFile.py
@@ -477,7 +477,7 @@ Group:
                 value = info[k]
 
                 if os.path.isfile(value) or os.path.isdir(value):
-                    if trimDir and eups.utils.commonpath([trimDir, value]) == trimDir:
+                    if trimDir and eups.utils.isSubpath(value, trimDir):
                         if trimDir == value:
                             pass        # special case: we are setting something to trimDir
                         else:
@@ -488,7 +488,7 @@ Group:
                                 if dirName and "ups_dir" in info:
                                     dirName = os.path.join(dirName, info["ups_dir"])
 
-                                if dirName and eups.utils.commonpath([dirName, info[k]]) == dirName:
+                                if dirName and eups.utils.isSubpath(info[k], dirName):
                                     info[k] = re.sub("^%s/" % dirName, "", info[k])
 
                     if os.path.isabs(info[k]):

--- a/python/eups/distrib/Repositories.py
+++ b/python/eups/distrib/Repositories.py
@@ -867,7 +867,7 @@ class Repositories(object):
         """
         buildDir = self.getBuildDirFor(productRoot, product, version, options, flavor)
         if os.path.exists(buildDir):
-            if force or (productRoot and utils.commonpath([productRoot, buildDir]) == productRoot):
+            if force or (productRoot and utils.isSubdir(buildDir, productRoot)):
                 if self.verbose > 1: 
                     print("removing", buildDir, file=self.log)
                 rmCmd = "rm -rf %s" % buildDir

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -2,7 +2,14 @@
 Utility functions used across EUPS classes.
 """
 from __future__ import print_function
-import time, os, sys, glob, re, shutil, tempfile, pwd
+import time
+import os
+import sys
+import glob
+import re
+import shutil
+import tempfile
+import pwd
 
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 # Python 2/3 compatibility layer
@@ -78,8 +85,6 @@ def _svnRevision(file=None, lastChanged=False):
         return matches["oldest"], matches["youngest"], tuple(matches["flags"])
 
     raise RuntimeError("svnversion returned unexpected result \"%s\"" % res[:-1])
-
-import os, re
 
 def version():
     """Get the eups version from git; if this isn't available consult git.version in $EUPS_DIR"""
@@ -851,40 +856,22 @@ class AtomicFile(object):
         self._fp.close()
         os.rename(self._tmpfn, self._fn)
 
-def commonpath(paths):
-    """Given a sequence of path names, returns the longest common sub-path.
+def isSubpath(path, root):
+    """!Return True if path is root or in root
 
-    Taken from python3.5 implementation
+    @param[in] path  path to a directory or file
+    @param[in] root  path to a directory; "" is treated as the current directory
+
+    @note
+    - path and root are both expanded to absolute paths with symbolic links resolved
+    - does not check that root or path exist
     """
-
-    if not paths:
-        raise ValueError('commonpath() arg is an empty sequence')
-
-    if isinstance(paths[0], bytes):
-        sep = '/'
-        curdir = '.'
-    else:
-        sep = '/'
-        curdir = '.'
-
-    split_paths = [path.split(sep) for path in paths]
-
-    try:
-        isabs, = set(p[:1] == sep for p in paths)
-    except ValueError:
-        raise ValueError("Can't mix absolute and relative paths")
-
-    split_paths = [[c for c in s if c and c != curdir] for s in split_paths]
-    s1 = min(split_paths)
-    s2 = max(split_paths)
-    common = s1
-    for i, c in enumerate(s1):
-        if c != s2[i]:
-            common = s1[:i]
-            break
-
-    prefix = sep if isabs else sep[:0]
-    return prefix + sep.join(common)
+    path = os.path.realpath(path)
+    root = os.path.realpath(root)
+    if path == root:
+        return True
+    # append trailing slash to root to avoid "/a/bbb" being treated as a subpath of "a/b"
+    return path.startswith(os.path.join(root, ""))
 
 if __name__ == "__main__":
     data = {

--- a/tests/testDyldLibraryPath.py
+++ b/tests/testDyldLibraryPath.py
@@ -36,11 +36,16 @@ unsetup dyldtest
 echo $DYLD_LIBRARY_PATH
 """;
 
+TestDir = os.path.abspath(os.path.dirname(__file__))
+
 class DyldLibraryPath(unittest.TestCase):
 
     def setUp(self):
         # remove any SETUP_ variables from the environment
         # as well as EUPS_DIR
+        self.initialDir = os.path.abspath(".")
+        os.chdir(TestDir)
+
         self.env = os.environ.copy()
 
         for key in self.env.keys():
@@ -50,15 +55,14 @@ class DyldLibraryPath(unittest.TestCase):
         self.env.pop('EUPS_DIR', None)
 
     def tearDown(self):
-        pass
+        os.chdir(self.initialDir)
 
     def _run_script(self, shell, cmds, expect):
         # Run script in the cleaned-up environment
         try:
             output = subprocess.check_output([shell, '-c', cmds], stderr=subprocess.STDOUT, env=self.env)
         except subprocess.CalledProcessError as e:
-            args_str = ', '.join([ "%s=%s" % (k, v) for (k, v) in args.items()])
-            self.fail("Failed to run test for shell %s with args={%s}.\nretcode=%s\noutput: %s" % (shell, args_str, e.returncode, e.output))
+            self.fail("Failed to run test for shell %s with args={%s}.\nretcode=%s\noutput: %s" % (shell, cmds, e.returncode, e.output))
 
         self.assertEqual(output, expect)
 


### PR DESCRIPTION
Fix #75 Cannot declare packages: eups declare: Can't mix absolute and relative paths as described on that issue.

Note that this makes a number of unit tests pass that failed for me before (though I am not sure they would fail for all users; I think it depends on how one installs eups).

Also fixed two bugs in tests/testDyldLibraryPath.py
- it could only be run from the test directory (which is not where "make tests" ran it)
- the failure message relied on a non-existent variable