### PR TITLE
Fix more tests

### DIFF
--- a/tests/testCommon.py
+++ b/tests/testCommon.py
@@ -1,7 +1,6 @@
 import os, sys, unittest
 
 testEupsStack = os.path.dirname(__file__)
-os.environ["EUPS_DIR"] = os.path.dirname(testEupsStack)
 
 # clear out any products setup in the environment as these can interfere 
 # with the tests
@@ -39,30 +38,3 @@ def run(suite, exit=True):
         sys.exit(status)
     else:
         return status
-
-#-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-
-def findFileFromRoot(ifile):
-    """Find file which is specified as a path relative to the toplevel directory;
-    we start in $cwd and walk up until we find the file (or throw IOError if it doesn't exist)
-
-    This is useful for running tests that may be run from <dir>/tests or <dir>"""
-    
-    if os.path.isfile(ifile):
-        return ifile
-
-    ofile = None
-    file = ifile
-    while file != "":
-        dirname, basename = os.path.split(file)
-        if ofile:
-            ofile = os.path.join(basename, ofile)
-        else:
-            ofile = basename
-
-        if os.path.isfile(ofile):
-            return ofile
-
-        file = dirname
-
-    raise IOError("Can't find %s" % ifile)

--- a/tests/testEups.py
+++ b/tests/testEups.py
@@ -401,8 +401,6 @@ class EupsTestCase(unittest.TestCase):
         # basic find
         prods = self.eups.findProducts("python")
         self.assertEquals(len(prods), 2)
-        if prods[0].version == "2.6":
-            prods.reverse()
         self.assertEquals(prods[0].name, "python")
         self.assertEquals(prods[0].version, "2.5.2")
         self.assertEquals(prods[1].name, "python")


### PR DESCRIPTION
Fixes the test failures from using the "current" tag, which is not a valid tag. It turns out that the tag "latest" is valid, so I changed all instances of "current" to "latest" in the two unit tests with failures. This leaves just one failure of `testDeclare`:

    ======================================================================
    ERROR: testDeclare (testEups.EupsTestCase)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/Users/rowen/UW/LSST/eups_git/tests/testEups.py", line 369, in testDeclare
        self.eups.undeclare("newprod")
      File "/Users/rowen/UW/LSST/lsstsw/eups/git/python/eups/Eups.py", line 2742, in undeclare
        (productName, "\" \"".join(versionList)))
    EupsException: Product newprod has versions "1.0" "tag:beta"; please choose one and try again

I also took the opportunity to clean up two minor issues in `tests/testCommon.py`:
 
-  stop setting EUPS_DIR to an invalid value in test
- remove unused function findFileFromRoot