### PR TITLE
open pickle file in binary mode

### DIFF
--- a/python/eups/stack/ProductStack.py
+++ b/python/eups/stack/ProductStack.py
@@ -299,7 +299,7 @@ class ProductStack(object):
             self.lookup[flavor] = {}
         flavorData = self.lookup[flavor]
 
-        fd = utils.AtomicFile(file, "w")
+        fd = utils.AtomicFile(file, "wb")
         pickle.dump(flavorData, fd)
         fd.close()
         self.modtimes[file] = os.stat(file).st_mtime

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -823,19 +823,19 @@ class AtomicFile(object):
 
         Constructor arguments:
             fn:      filename (string)
-          mode:      the read/write mode (string), must be equal to "w" for now
+          mode:      the read/write mode (string), must be equal to "wb" for now
 
         Return value:
             file object
     """
     def __init__(self, fn, mode):
-        assert(mode == "w")   # no other modes are currently implemented
+        assert(mode in ["w", "wb"])   # no other modes are currently implemented
 
         self._fn = fn
         dir = os.path.dirname(fn)
 
         (self._fh, self._tmpfn) = tempfile.mkstemp(suffix='.tmp', dir=dir)
-        self._fp = os.fdopen(self._fh, "w")
+        self._fp = os.fdopen(self._fh, mode)
 
     def __getattr__(self, name): 
         try:

--- a/tests/testProduct.py
+++ b/tests/testProduct.py
@@ -37,7 +37,7 @@ class ProductTestCase(unittest.TestCase):
         self.assertIn("mine", p.tags)
 
     def testPersist(self):
-        fd = file("test_product.pickle", "w")
+        fd = file("test_product.pickle", "wb")
         self.prod.persist(fd)
         fd.close()
         fd = file("test_product.pickle")


### PR DESCRIPTION
This change fixes the problem described in #77 when a pickle file is opened in binary mode following the solution from @mjuric.