### PR TITLE
Fix 'eups declare' behavior, and the associated unit test

### DIFF
--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -2568,10 +2568,25 @@ The what argument tells us what sort of state is expected (allowed values are de
                     info = " (%s)" % "; ".join(differences)
 
                 if tag:
-                    print("You asked me to redeclare %s %s%s; I'll only declare the tag" % \
-                        (productName, versionName, info), file=utils.stdinfo)
-                        
-                    versionName = "tag:%s" % tag # Declare a tag:XXX version with those differences
+                    # Allow re-declaration of a product's directory if it's been previously
+                    # declared with a 'tag:<tagname>' version. This allows for convenient
+                    # usage such as:
+                    #
+                    # setup -r . -t mytest
+                    # ... change to a different copy of the product
+                    # setup -r . -t mytest
+                    #
+                    # where now the second copy is the one that's declared.
+                    #
+                    # Otherwise, refuse to change anything other than the tag.
+                    #
+                    if versionName == "tag:%s" % tag:
+                        print("Redeclaring product %s %s in '%s' with tablefile '%s'" % (productName, versionName, productDir, tablefile),
+                            file=utils.stdinfo)
+                    else:
+                        dodeclare=False
+                        print("You asked me to redeclare %s %s%s; I'll only declare the tag" % \
+                            (productName, versionName, info), file=utils.stdinfo)
                 else:
                     raise EupsException("Redeclaring %s %s%s; specify force to proceed" %
                                         (productName, versionName, info))

--- a/tests/testEups.py
+++ b/tests/testEups.py
@@ -298,7 +298,7 @@ class EupsTestCase(unittest.TestCase):
         self.assertRaises(EupsException, self.eups.declare, "newprod", "1.1", pdir10, None, table)
         # we can move the tag but not the directory
         self.eups.declare("newprod", "1.0", pdir11, None, table, tag="beta")
-        self.assertEquals(self.eups.findProduct("newprod", self.eups.tags.getTag("beta")).dir, pdir11)
+        self.assertEquals(self.eups.findProduct("newprod", self.eups.tags.getTag("beta")).dir, pdir10)
         # ...unless we force it
         self.eups.force = True
         self.eups.declare("newprod", "1.1", pdir10, None, table, tag="beta")


### PR DESCRIPTION
Fix a problem introduced in 6e234b4. I think the intent of that commit was to allow re-declaration of a product's directory if it's been previously declared with a 'tag:<tagname>' version.  This allows for convenient usage such as:
```
setup -r . -t mytest
# ... change to a different copy of the product ...
setup -r . -t mytest
```
where now the second copy is the one that's declared (and declared with a version of 'tag:mytest', and a tag 'mytest').  The way this was implemented, however, has had an odd side-effect of allowing things such as:
```
eups declare -r /stack/foo/1.2 foo 1.2 -t bar
eups declare -r /stack/foo/1.4 foo 1.2 -t bar
```
which would result in the following declared products:
```
foo, with version 1.2 in /stack/foo/1.2
foo, with version tag:bar in /stack/foo/1.4
```
(and, more broadly, redeclaration with _any_ change would always end up declaring a product with version 'tag:<tagname>')

The implementation has now been changed to return to the old behavior of refusing to redeclare if there are changes in productDir, etc., unless the version equals 'tag:<tagname>'.