### PR TITLE
Reintroduce tap package variable

### DIFF
--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -672,9 +672,8 @@ default_prep()
 	# to apply once all tarballs have been expanded.
 	#
 	# To be recognized as at TaP package, there must be no files (other
-	# than those starting with a dot) in the package root directory unless
-	# the file ".tap_package" exists, and there must be a directory named
-	# 'upstream'
+	# than those starting with a dot) in the package root directory, and
+	# there must be a directory named 'upstream'
 
 	if [[ -d "$UPSTREAM_DIR" ]]; then
 	
@@ -684,8 +683,8 @@ default_prep()
 		fi
 
 		# verify that there are no files (other than .* or _*) in $pkgdir
-		# packagers: it's possible to override this check by creating .tap_package
-		if [[ ! -f ".tap_package" && ! -z $(find . -maxdepth 1 -mindepth 1 ! -name ".*" ! -name "_*" -a -type f) ]]; then
+		# packagers: it's possible override this ckeck with TAP_PACKAGE=1
+		if [[ "$TAP_PACKAGE" != 1 && ! -z $(find . -maxdepth 1 -mindepth 1 ! -name ".*" ! -name "_*" -a -type f) ]]; then
 			die "files found in root directory; guessing this is not a TaP package."
 		fi
 

--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -683,8 +683,9 @@ default_prep()
 		fi
 
 		# verify that there are no files (other than .* or _*) in $pkgdir
-		# packagers: it's possible override this ckeck with TAP_PACKAGE=1
-		if [[ "$TAP_PACKAGE" != 1 && ! -z $(find . -maxdepth 1 -mindepth 1 ! -name ".*" ! -name "_*" -a -type f) ]]; then
+		# packagers: it's possible override this check by setting TAP_PACKAGE=1 in eupspkg.cfg.sh
+		# (deprecated) can also be overriden by touching a .tap_package file (mistakenly introduced in v1.5.8, will be removed at a later date)
+		if [[ "$TAP_PACKAGE" != 1 && ! -f ".tap_package" && ! -z $(find . -maxdepth 1 -mindepth 1 ! -name ".*" ! -name "_*" -a -type f) ]]; then
 			die "files found in root directory; guessing this is not a TaP package."
 		fi
 

--- a/python/eups/distrib/eupspkg.py
+++ b/python/eups/distrib/eupspkg.py
@@ -385,10 +385,10 @@ r"""
 
        TaP         -- the "tarball-and-patch" package; if a directory named
                       'upstream' exists in package root (and no other files
-                      are found there or the file ".tap_package" exists),
-                      extract any tarballs from 'upstream' and apply any
-                      patches found in 'patches', before proceeding to
-                      autodetect the build system as described above.
+                      are found there), extract any tarballs from 'upstream'
+                      and apply any patches found in 'patches', before
+                      proceeding to autodetect the build system as described
+                      above.
 
                       This is useful for packages created out of git
                       repositories that are just containers for external


### PR DESCRIPTION
Tested by running:
```
(
    cd cfitsio &&
    git reset --hard &&
    git clean -f &&
    source ../bin/setups.sh &&
    touch blah &&
    echo "TAP_PACKAGE=1" >> ups/eupspkg.cfg.sh &&
    rm -rf _eupspkg &&
    eupspkg -e fetch &&
    eupspkg -e prep
)
```
and
```
(
    cd cfitsio &&
    git reset --hard &&
    git clean -f &&
    source ../bin/setups.sh &&
    touch blah &&
    touch .tap_package &&
    rm -rf _eupspkg &&
    eupspkg -e fetch &&
    eupspkg -e prep
)
```
on a cloned `lsst/cfitsio` repository. (n.b., a unit test should be made for these, once there's some infrastructure to make that easy to do).