### PR TITLE
Support spaces in paths for EUPS installation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -32,8 +32,8 @@ install : show
 	@: directories are the same\; they may have different names due to
 	@: symbolic links and automounters
 	@:
-	@if [ -d $(EUPS_DIR) ]; then \
-	    if [ `ls -id $(EUPS_DIR) | awk '{print $$1}'` = `ls -id . | awk '{print $$1}'` ]; then \
+	@if [ -d "$(EUPS_DIR)" ]; then \
+	    if [ `ls -id "$(EUPS_DIR)" | awk '{print $$1}'` = `ls -id . | awk '{print $$1}'` ]; then \
 		echo "The destination directory is the same" \
 			"as the current directory; aborting." >&2; \
 		echo ""; \
@@ -44,11 +44,15 @@ install : show
 	@:
 	@: Delete the contents of $EUPS_DIR, if exists, keeping only the 'site' subdirectory
 	@:
-	@ if [ -d $(EUPS_DIR) ]; then \
-	        chmod -R u+w $(EUPS_DIR)/* ; \
-		$(RM) -r `ls -d $(EUPS_DIR)/* | awk '{ if($$1 != "site") { print } }'`; \
+	@ if [ -d "$(EUPS_DIR)" ]; then \
+	        chmod -R u+w "$(EUPS_DIR)"/* ; \
+	        for f in "$(EUPS_DIR)"/*; do \
+		    if [ -d "$$f" ] && [ `basename "$$f"` != "site" ]; then \
+			rm -r "$$f"; \
+		    fi; \
+		done; \
 	else \
-		mkdir -p $(EUPS_DIR); \
+		mkdir -p "$(EUPS_DIR)"; \
 	fi
 
 	@:
@@ -58,16 +62,16 @@ install : show
 		echo You have not specified EUPS_PATH >&2; \
 		exit 1; \
 	fi 
-	@ for d in $(shell perl -e 'foreach $$d (split(":","$(EUPS_PATH)")) { print "$$d\n"}'); do \
-		if [ ! -d $$d ]; then \
-			mkdir -p $$d; \
+	@ for d in "$(shell perl -e 'foreach $$d (split(":","$(EUPS_PATH)")) { print "$$d\n"}')"; do \
+		if [ ! -d "$$d" ]; then \
+			mkdir -p "$$d"; \
 		fi; \
 	done
-	@ for db in $(EUPS_DB); do \
-		if [ -d $$db ]; then \
+	@ for db in "$(EUPS_DB)"; do \
+		if [ -d "$$db" ]; then \
 			echo "EUPS database $$db already exists"; \
 		else \
-			mkdir -p $$db; \
+			mkdir -p "$$db"; \
 		fi; \
 	done
 
@@ -76,14 +80,14 @@ install : show
 	@:
 	@ for f in $(SUBDIRS); do \
 		(\
-		   if [ ! -d $(EUPS_DIR)/$$f ]; then mkdir $(EUPS_DIR)/$$f; fi; \
+		   if [ ! -d "$(EUPS_DIR)"/$$f ]; then mkdir "$(EUPS_DIR)"/$$f; fi; \
 		   cd $$f ; \
 		   echo In $$f; $(MAKE) $(MFLAGS) install \
                 ); \
 	done
-	- cp Makefile README  Release_Notes gpl.txt $(EUPS_DIR)
+	- cp Makefile README  Release_Notes gpl.txt "$(EUPS_DIR)"
 
-	echo $(VERSION) > $(EUPS_DIR)/git.version
+	echo $(VERSION) > "$(EUPS_DIR)/git.version"
 	@echo "Remember to source $(EUPS_DIR)/bin/setups.{c,z,}sh"
 declare :
 	@vers="$(VERSION)"; \
@@ -96,11 +100,13 @@ show : git.version
 	@echo "Your EUPS database[s] will be               $(EUPS_DB)"
 	@echo "Your EUPS version is                        $(VERSION)"
 	@ \
-	EUPS_DB_DIR=`echo $(EUPS_PATH) | sed -e 's/:.*//'`; \
-	if [ -d $$EUPS_DB_DIR/site ]; then \
+	EUPS_DB_DIR=`echo "$(EUPS_PATH)" | sed -e 's/:.*//'`; \
+	if [ -d "$$EUPS_DB_DIR/site" ]; then \
 		echo "Your site configuration files are:"; \
-		for f in `ls $$EUPS_DB_DIR/site/*[a-z] | grep -v Makefile`; do \
-		    echo "   $$f"; \
+		for f in "$$EUPS_DB_DIR"/site/*[a-z]; do \
+		    if [ -n "`echo $$f | grep -v Makefile`" ]; then \
+		        echo "   $$f"; \
+		    fi; \
 		done; \
 	else \
 		echo "Your site configuration files will be in    $$EUPS_DB_DIR/site"; \

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -8,16 +8,16 @@ SHELL = /bin/sh
 all :;
 
 install :
-	chmod u+w $(EUPS_DIR)/bin
-	@ find $(EUPS_DIR)/bin -type d -exec chmod u+w {} \;
-	@ find $(EUPS_DIR)/bin -name "*.pyc" -exec chmod u+w {} \;
-	@ ./mksetup $(EUPS_PYTHON) $(EUPS_DIR) $(EUPS_PATH) $(SETUP_ALIASES)
-	cp Makefile mksetup setups.*sh eups eups_impl.py eups_setup eups_setup_impl.py eupspkg pkgautoversion $(EUPS_DIR)/bin
+	chmod u+w "$(EUPS_DIR)/bin"
+	@ find "$(EUPS_DIR)/bin" -type d -exec chmod u+w {} \;
+	@ find "$(EUPS_DIR)/bin" -name "*.pyc" -exec chmod u+w {} \;
+	@ ./mksetup "$(EUPS_PYTHON)" "$(EUPS_DIR)" "$(EUPS_PATH)" "$(SETUP_ALIASES)"
+	cp Makefile mksetup setups.*sh eups eups_impl.py eups_setup eups_setup_impl.py eupspkg pkgautoversion "$(EUPS_DIR)/bin"
 	@ echo Building .pyc files
-	@ $(EUPS_PYTHON) -c "import compileall; compileall.compile_dir('$(EUPS_DIR)/bin')"
+	@ "$(EUPS_PYTHON)" -c "import compileall; compileall.compile_dir('$(EUPS_DIR)/bin')"
 # Prevent recompilation by a different python (which can introduce race conditions).
-	@ find $(EUPS_DIR)/bin -name "*.pyc" -exec chmod ugo-w {} \;
-	chmod ugo-w $(EUPS_DIR)/bin
+	@ find "$(EUPS_DIR)/bin" -name "*.pyc" -exec chmod ugo-w {} \;
+	chmod ugo-w "$(EUPS_DIR)/bin"
 
 TAGS :
 	etags eups eups_setup *.py

--- a/bin/eups.in
+++ b/bin/eups.in
@@ -3,4 +3,4 @@
 #  #!/usr/bin/env python options
 #
 unset PYTHONSTARTUP
-@EUPS_PYTHON@ -S "$EUPS_DIR/bin/eups_impl.py" "$@"
+"@EUPS_PYTHON@" -S "$EUPS_DIR/bin/eups_impl.py" "$@"

--- a/bin/eups_setup.in
+++ b/bin/eups_setup.in
@@ -3,4 +3,4 @@
 #  #!/usr/bin/env python options
 #
 unset PYTHONSTARTUP
-@EUPS_PYTHON@ -S "$EUPS_DIR/bin/eups_setup_impl.py" "$@"
+"@EUPS_PYTHON@" -S "$EUPS_DIR/bin/eups_setup_impl.py" "$@"

--- a/bin/mksetup
+++ b/bin/mksetup
@@ -68,6 +68,7 @@ if ("$?EUPS_DIR" == "1" ) then
 else
    setenv EUPS_DIR "%(eupsdir)s"
 endif
+set eupslocalpath = `echo "$EUPS_DIR" | sed -e "s/ /-+-/g"`
 
 if ("$?EUPS_PATH" == "0" ) then
     setenv EUPS_PATH ""
@@ -89,7 +90,8 @@ endif
 # n.b.: we reset the flavor in SETUP_EUPS so eups doesn't show up in 'eups list'
 #       and similar. This is for backwards compatibility.
 eval `"%(setup)s" "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" eups -r "$EUPS_DIR"`
-setenv SETUP_EUPS "eups LOCAL:$EUPS_DIR -f (none) -Z (none)"
+setenv SETUP_EUPS "eups LOCAL:$eupslocalpath -f (none) -Z (none)"
+unset eupslocalpath
 
 """ % {"bindir" : bindir, "eupsdir" : eupsdir, "prefix" : prefix, \
            "pythondir" : pythondir, "setup" : setup,  "unique_eups_path" : unique_eups_path, \
@@ -117,6 +119,7 @@ export EUPS_SHELL=sh
 
 # allow the user to override EUPS_DIR
 export EUPS_DIR=${EUPS_DIR:-%(eupsdir)s}
+eupslocalpath=$(echo "$EUPS_DIR" | sed -e "s/ /-+-/g")
 
 # Set EUPS_PATH, appending any pre-existing EUPS_PATH (and only keeping
 # one copy of each directory)
@@ -126,7 +129,8 @@ export EUPS_PATH=`"%(eupspython)s" -E -S -c '%(unique_path)s' "$EUPS_PATH" "%(pr
 # n.b.: we reset the flavor in SETUP_EUPS so eups doesn't show up in 'eups list'
 #       and similar. This is for backwards compatibility.
 eval `"%(setup)s" "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" eups -r "$EUPS_DIR"`
-export SETUP_EUPS="eups LOCAL:$EUPS_DIR -f (none) -Z (none)"
+export SETUP_EUPS="eups LOCAL:$eupslocalpath -f (none) -Z (none)"
+unset eupslocalpath
 
 # bash auto-completion
 if [ X$BASH_COMPLETION != X -a -f "$EUPS_DIR/etc/bash_completion.d/eups" ]; then

--- a/bin/mksetup
+++ b/bin/mksetup
@@ -120,12 +120,12 @@ export EUPS_DIR=${EUPS_DIR:-%(eupsdir)s}
 
 # Set EUPS_PATH, appending any pre-existing EUPS_PATH (and only keeping
 # one copy of each directory)
-export EUPS_PATH=`%(eupspython)s -E -S -c '%(unique_path)s' "$EUPS_PATH" "%(prefix)s"`
+export EUPS_PATH=`"%(eupspython)s" -E -S -c '%(unique_path)s' "$EUPS_PATH" "%(prefix)s"`
 
 # setup EUPS, using EUPS
 # n.b.: we reset the flavor in SETUP_EUPS so eups doesn't show up in 'eups list'
 #       and similar. This is for backwards compatibility.
-eval `%(setup)s "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" eups -r "$EUPS_DIR"`
+eval `"%(setup)s" "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" eups -r "$EUPS_DIR"`
 export SETUP_EUPS="eups LOCAL:$EUPS_DIR -f (none) -Z (none)"
 
 # bash auto-completion

--- a/bin/mksetup
+++ b/bin/mksetup
@@ -88,7 +88,7 @@ endif
 # setup EUPS, using EUPS
 # n.b.: we reset the flavor in SETUP_EUPS so eups doesn't show up in 'eups list'
 #       and similar. This is for backwards compatibility.
-eval `%(setup)s "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" eups -r "$EUPS_DIR"`
+eval `"%(setup)s" "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" eups -r "$EUPS_DIR"`
 setenv SETUP_EUPS "eups LOCAL:$EUPS_DIR -f (none) -Z (none)"
 
 """ % {"bindir" : bindir, "eupsdir" : eupsdir, "prefix" : prefix, \

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -12,7 +12,8 @@ make_and_install()
 {
 	(
 		# configure
-		PREFIX=$(mktemp -d -t XXXX)
+		PREFIX=$(mktemp -d -t "eupstest XXXXXX")
+
 		./configure --prefix="$PREFIX" --with-python=$(which python)
 
 		# install & test

--- a/configure
+++ b/configure
@@ -1731,7 +1731,7 @@ if test "${with_python+set}" = set; then :
   withval=$with_python; EUPS_PYTHON=$(echo $withval)
 else
   EUPS_PYTHON=$(which python)
-    if [ $EUPS_PYTHON != /usr/bin/python ]; then
+    if [ "$EUPS_PYTHON" != /usr/bin/python ]; then
       as_fn_error $? "Your current python version isn't /usr/bin/python, please rerun configure specifying --with-python.
 --with-python=$(which python) will force eups to use your current python version,
 --with-python=/usr/bin/python will force eups to use system-installed python" "$LINENO" 5
@@ -1740,7 +1740,8 @@ else
 fi
 
 
-if [ -x $EUPS_PYTHON ]; then $EUPS_PYTHON -c "import sys;print(\"EUPS_PYTHON :\ninterpreter : %s\nversion : %s\" % (sys.executable, sys.version))" > /dev/null 2>&1 || as_fn_error $? "$EUPS_PYTHON does not seem to be a valid python interpreter" "$LINENO" 5
+if [ -x "$EUPS_PYTHON" ]; then
+    "$EUPS_PYTHON" -c "import sys;print(\"EUPS_PYTHON :\ninterpreter : %s\nversion : %s\" % (sys.executable, sys.version))" > /dev/null 2>&1 || as_fn_error $? "$EUPS_PYTHON does not seem to be a valid python interpreter" "$LINENO" 5
 else
     as_fn_error $? "$EUPS_PYTHON doesn't exists or doesn't have execute permission granted" "$LINENO" 5
 fi
@@ -1748,7 +1749,7 @@ fi
 
 
 # Allow them to use --prefix as an alias for --with-eups_dir
-if test X$prefix != XNONE; then
+if test "X$prefix" != "XNONE"; then
    with_eups_dir=$prefix
 fi
 
@@ -2992,5 +2993,5 @@ if [ X$SETUP_ALIASES != X ]; then
    echo "addAlias(`echo $SETUP_ALIASES | sed -e 's/^.*://'`, unsetup \$@)" >> ups/eups.table
 fi
 
-(export EUPS_DIR=$PWD; cd bin; $EUPS_PYTHON ./mksetup $EUPS_PYTHON $EUPS_DIR $EUPS_PATH $SETUP_ALIASES) || exit $?
+(export EUPS_DIR="$PWD"; cd bin; "$EUPS_PYTHON" ./mksetup "$EUPS_PYTHON" "$EUPS_DIR" "$EUPS_PATH" "$SETUP_ALIASES") || exit $?
 make git.version

--- a/configure
+++ b/configure
@@ -1715,8 +1715,8 @@ fi
 if test "${with_eups+set}" = set; then :
   withval=$with_eups; EUPS_PATH=$(echo $withval | perl -pe 's|/*$||')
 else
-  if [ -z $EUPS_PATH ]; then
-       EUPS_PATH=${prefix}/share
+  if [ -z "$EUPS_PATH" ]; then
+       EUPS_PATH="${prefix}/share"
     else
        EUPS_PATH=$EUPS_PATH
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_ARG_WITH(python,
    ]) 
 
 if [[ -x $EUPS_PYTHON ]]; then
-    $EUPS_PYTHON -c "import sys;print \"EUPS_PYTHON :\ninterpreter : %s\nversion : %s\" % (sys.executable, sys.version)" > /dev/null 2>&1 || AC_MSG_ERROR([$EUPS_PYTHON does not seem to be a valid python interpreter])
+    $EUPS_PYTHON -c "import sys;print(\"EUPS_PYTHON :\ninterpreter : %s\nversion : %s\" % (sys.executable, sys.version))" > /dev/null 2>&1 || AC_MSG_ERROR([$EUPS_PYTHON does not seem to be a valid python interpreter])
 else
     AC_MSG_ERROR([$EUPS_PYTHON doesn't exists or doesn't have execute permission granted])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -29,15 +29,15 @@ AC_ARG_WITH(python,
    [AS_HELP_STRING(--with-python=PYTHON, [Use python interpreter PYTHON (e.g. /usr/local/bin/python) to run eups])],
    [EUPS_PYTHON=$(echo $withval)],
    [EUPS_PYTHON=$(which python)
-    if [[ $EUPS_PYTHON != /usr/bin/python ]]; then
+    if [[ "$EUPS_PYTHON" != /usr/bin/python ]]; then
       AC_MSG_ERROR([Your current python version isn't /usr/bin/python, please rerun configure specifying --with-python. 
 --with-python=$(which python) will force eups to use your current python version, 
 --with-python=/usr/bin/python will force eups to use system-installed python])
     fi
    ]) 
 
-if [[ -x $EUPS_PYTHON ]]; then
-    $EUPS_PYTHON -c "import sys;print(\"EUPS_PYTHON :\ninterpreter : %s\nversion : %s\" % (sys.executable, sys.version))" > /dev/null 2>&1 || AC_MSG_ERROR([$EUPS_PYTHON does not seem to be a valid python interpreter])
+if [[ -x "$EUPS_PYTHON" ]]; then
+    "$EUPS_PYTHON" -c "import sys;print(\"EUPS_PYTHON :\ninterpreter : %s\nversion : %s\" % (sys.executable, sys.version))" > /dev/null 2>&1 || AC_MSG_ERROR([$EUPS_PYTHON does not seem to be a valid python interpreter])
 else
     AC_MSG_ERROR([$EUPS_PYTHON doesn't exists or doesn't have execute permission granted])
 fi
@@ -45,7 +45,7 @@ fi
 AC_SUBST(EUPS_PYTHON)
 
 # Allow them to use --prefix as an alias for --with-eups_dir
-if test X$prefix != XNONE; then
+if test "X$prefix" != "XNONE"; then
    with_eups_dir=$prefix
 fi
 
@@ -120,5 +120,5 @@ if [[ X$SETUP_ALIASES != X ]]; then
    echo "addAlias(`echo $SETUP_ALIASES | sed -e 's/^.*://'`, unsetup \$@)" >> ups/eups.table
 fi
 
-(export EUPS_DIR=$PWD; cd bin; $EUPS_PYTHON ./mksetup $EUPS_PYTHON $EUPS_DIR $EUPS_PATH $SETUP_ALIASES) || exit $?
+(export EUPS_DIR="$PWD"; cd bin; "$EUPS_PYTHON" ./mksetup "$EUPS_PYTHON" "$EUPS_DIR" "$EUPS_PATH" "$SETUP_ALIASES") || exit $?
 make git.version

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,8 @@ dnl
 AC_ARG_WITH(eups,
    [AS_HELP_STRING(--with-eups=DIR, [Use DIR as root for installed products (EUPS_PATH)])],
    [EUPS_PATH=$(echo $withval | perl -pe 's|/*$||')],
-   [if [[ -z $EUPS_PATH ]]; then
-       EUPS_PATH=${prefix}/share
+   [if [[ -z "$EUPS_PATH" ]]; then
+       EUPS_PATH="${prefix}/share"
     else
        EUPS_PATH=$EUPS_PATH
     fi

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,6 @@ eups.aux : eups.tex
 	@ if ! echo | latex $(LATEXFLAGS) eups.tex; then \
 		echo "Could not build eups.aux (ignoring)"; \
 	fi
-		
 
 eups.dvi : eups.aux
 	@ if ! echo | latex $(LATEXFLAGS) eups.tex; then \
@@ -31,7 +30,7 @@ eups.html : eups.aux
 		echo "<H1><CODE>eups</CODE> documentation</H1>" >> eups.html; \
 		echo "We're sorry, but we failed to build the <code>eups</code>" >> eups.html; \
 		echo "documentation as we couldn't find <code>latex2html</code>." >> eups.html; \
-		echo "The <A HREF=$(EUPS_DIR)/doc/eups.pdf>pdf documentation</A> was built successfully." >> eups.html;\
+		echo "The <A HREF=\"$(EUPS_DIR)/doc/eups.pdf\">pdf documentation</A> was built successfully." >> eups.html;\
 		echo "</HTML>" >> eups.html; \
 	fi
 
@@ -41,7 +40,7 @@ eups.pdf : eups.aux
 	fi
 
 install : eups.pdf eups.html
-	@ if ! cp Makefile *.tex eups.pdf eups.html $(EUPS_DIR)/doc; then \
+	@ if ! cp Makefile *.tex eups.pdf eups.html "$(EUPS_DIR)/doc"; then \
 		echo "Not all documentation files copied (ignoring)"; \
 	fi
 

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -5,10 +5,10 @@ SUBDIRS=bash_completion.d
 all :;
 
 install :
-	cp Makefile ac_eups.m4 $(EUPS_DIR)/etc
+	cp Makefile ac_eups.m4 "$(EUPS_DIR)/etc"
 	@ for f in $(SUBDIRS); do \
 		(\
-		   if [ ! -d $(EUPS_DIR)/$$f ]; then mkdir $(EUPS_DIR)/etc/$$f; fi; \
+		   if [ ! -d "$(EUPS_DIR)"/$$f ]; then mkdir "$(EUPS_DIR)"/etc/$$f; fi; \
 		   cd $$f ; \
 		   echo In $$f; $(MAKE) $(MFLAGS) install \
                 ); \

--- a/etc/bash_completion.d/Makefile
+++ b/etc/bash_completion.d/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/sh
 all :;
 
 install :
-	cp eups $(EUPS_DIR)/etc/bash_completion.d
+	cp eups "$(EUPS_DIR)/etc/bash_completion.d"
 
 clean :
 	- /bin/rm -f *~ core

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -8,7 +8,7 @@ install :
 	cp bunit.sh eupspkg.sh "$(EUPS_DIR)/lib"
 	@ for f in $(SUBDIRS); do \
 		(\
-		   if [ ! -d $(EUPS_DIR)/$$f ]; then mkdir $(EUPS_DIR)/lib/$$f; fi; \
+		   if [ ! -d "$(EUPS_DIR)/$$f" ]; then mkdir "$(EUPS_DIR)/lib/$$f"; fi; \
 		   cd $$f ; \
 		   echo In $$f; $(MAKE) $(MFLAGS) install \
                 ); \

--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -737,7 +737,9 @@ default_config()
 			fix_autoconf_timestamps
 		fi
 
-		./configure $CONFIGURE_OPTIONS
+		# Use eval so that quoted strings in $CONFIGURE_OPTIONS
+		# expand properly (e.g. --prefix="$PREFIX")
+		eval ./configure $CONFIGURE_OPTIONS
 	fi
 }
 

--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -184,9 +184,9 @@ require_eups_version()
 	IFS=. read -ra SA <<< "$eups_ver"
 	IFS=. read -ra SB <<< "$1"
 
-	# Print the array as zero-padded string, so we can compare it leicographically
-	V1=$(printf "%05d" ${SA[@]})
-	V2=$(printf "%05d" ${SB[@]})
+	# Print the array as zero-padded string, so we can compare it lexicographically
+	V1=$(printf "%05d" "${SA[@]}")
+	V2=$(printf "%05d" "${SB[@]}")
 
 	if [[ "$V1" < "$V2" ]]; then
 		message=${2-"EUPS v$eups_ver too old for this package; v$1 or later required."}
@@ -1126,12 +1126,12 @@ MAKE_INSTALL_TARGETS=${MAKE_INSTALL_TARGETS:-"install"}	# Targets for invocation
 PRODUCTS_ROOT=${PRODUCTS_ROOT:-"$(eups path 0)/$(eups flavor)"}		# Root directory of EUPS-managed stack.
 PREFIX=${PREFIX:-"$PRODUCTS_ROOT/$PRODUCT/$VERSION"}			# Directory to which the product will be installed
 
-CONFIGURE_OPTIONS=${CONFIGURE_OPTIONS:-"--prefix $PREFIX"}		# Options passed to ./configure. Note that --prefix is NOT passed separately!
+CONFIGURE_OPTIONS=${CONFIGURE_OPTIONS:-"--prefix \"$PREFIX\""}		# Options passed to ./configure. Note that --prefix is NOT passed separately!
 # The following '--prefix=' is meant to clear any pre-set 'prefix' from a distutils.cfg or ~/.pydistutils.cfg
 # We can only specify a value for either --home XOR --prefix, not both.
 # So if we specify --home, we have to blank out --prefix:
 # See, e.g.,   http://stackoverflow.com/questions/4495120/combine-user-with-prefix-error-with-setup-py-install
-PYSETUP_INSTALL_OPTIONS=${PYSETUP_INSTALL_OPTIONS:-"--home $PREFIX --prefix="}	# Options passed to setup.py install. Note that --home is NOT passed separately!
+PYSETUP_INSTALL_OPTIONS=${PYSETUP_INSTALL_OPTIONS:-"--home \"$PREFIX\" --prefix="}	# Options passed to setup.py install. Note that --home is NOT passed separately!
 
 export CC=${CC:-cc}				# Autoconf prefers to look for gcc first, and the proper thing is to default to cc. This helps on Darwin.
 export CXX=${CXX:-c++}				# Autoconf prefers to look for gcc first, and the proper thing is to default to c++. This helps on Darwin.
@@ -1160,10 +1160,10 @@ ulimit -Su hard >/dev/null 2>&1 \
 
 IFS=':' read -ra _SCRIPTS <<< "$SCRIPTS"
 for _script in "${_SCRIPTS[@]}"; do
-	if [[ -f $_script ]]; then
+	if [[ -f "$_script" ]]; then
 		info "sourcing '$_script'."
-		. $_script
-	elif [[ -z $_script ]]; then
+		. "$_script"
+	elif [[ -z "$_script" ]]; then
 		continue
 	else
 		die "script '$_script' listed on the SCRIPTS path does not exist."

--- a/python/Makefile
+++ b/python/Makefile
@@ -9,14 +9,14 @@ PYFILES=eups
 all :;
 
 install :
-	@ find $(EUPS_DIR)/bin -type d -exec chmod u+w {} \;
-	@ find $(EUPS_DIR)/bin -name "*.pyc" -exec chmod u+w {} \;
-	cp -r $(PYFILES) $(EUPS_DIR)/python
+	@ find "$(EUPS_DIR)/bin" -type d -exec chmod u+w {} \;
+	@ find "$(EUPS_DIR)/bin" -name "*.pyc" -exec chmod u+w {} \;
+	cp -r $(PYFILES) "$(EUPS_DIR)/python"
 	@ echo Building .pyc files
-	@ $(EUPS_PYTHON) -c "import compileall; compileall.compile_dir('$(EUPS_DIR)/python')"
+	@ "$(EUPS_PYTHON)" -c "import compileall; compileall.compile_dir('$(EUPS_DIR)/python')"
 # Prevent recompilation by a different python (which can introduce race conditions).
-	@ find $(EUPS_DIR)/python -name "*.pyc" -exec chmod ugo-w {} \;
-	@ find $(EUPS_DIR)/python -type d -exec chmod ugo-w {} \;
+	@ find "$(EUPS_DIR)/python" -name "*.pyc" -exec chmod ugo-w {} \;
+	@ find "$(EUPS_DIR)/python" -type d -exec chmod ugo-w {} \;
 
 TAGS :
 	etags *.py

--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -756,7 +756,7 @@ The what argument tells us what sort of state is expected (allowed values are de
             args.pop(0);  eupsPathDir = utils.decodePath(args.pop(0))
 
         if len(args) > 1 and (args[0] == "-m"):
-            args.pop(0);  tablefile = args.pop(0)
+            args.pop(0);  tablefile = utils.decodePath(args.pop(0))
 
         if args:
             raise RuntimeError("Unexpected arguments: %s" % args)
@@ -2043,7 +2043,7 @@ The what argument tells us what sort of state is expected (allowed values are de
             setup_product_str = "%s %s -f %s -Z %s" % (
                 product.name, version, setupFlavor, utils.encodePath(product.stackRoot()))
             if tablefile:
-                setup_product_str += " -m %s" % (tablefile)
+                setup_product_str += " -m %s" % (utils.encodePath(tablefile))
 
             if not productRoot:
                 productRoot = product.dir

--- a/python/eups/distrib/eupspkg.py
+++ b/python/eups/distrib/eupspkg.py
@@ -980,7 +980,7 @@ tar xzvf %(eupspkg)s
 
 # Enter the directory unpacked from the tarball
 PKGDIR="$(find . -maxdepth 1 -type d ! -name ".*" | head -n 1)"
-test ! -z $PKGDIR
+test ! -z "$PKGDIR"
 cd "$PKGDIR"
 
 # If ./ups/eupspkg is not present, symlink in the default

--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -2308,7 +2308,7 @@ def system(cmd, noaction=False, verbosity=0, log=sys.stderr):
         setups_sh = os.path.join(environ['EUPS_DIR'],"bin","setups.sh")
 
         if "EUPS_PATH" in environ: # keep current path
-            cmd = "source %s; export EUPS_PATH=%s; %s " % (setups_sh, environ["EUPS_PATH"], cmd)
+            cmd = 'source "%s"; export EUPS_PATH="%s"; %s ' % (setups_sh, environ["EUPS_PATH"], cmd)
 
         if verbosity < 0:
             cmd += "> /dev/null 2>&1"

--- a/site/Makefile
+++ b/site/Makefile
@@ -3,14 +3,14 @@ all :
 
 install :
 	@ \
-	EUPS_DB_DIR=`echo $(EUPS_PATH) | sed -e 's/:.*//'`; \
-	mkdir -p $$EUPS_DB_DIR/site; \
+	EUPS_DB_DIR=`echo "$(EUPS_PATH)" | sed -e 's/:.*//'`; \
+	mkdir -p "$$EUPS_DB_DIR/site"; \
 	for f in startup.py; do \
-		if [ -f $$EUPS_DB_DIR/site/$$f ]; then \
+		if [ -f "$$EUPS_DB_DIR/site/$$f" ]; then \
 			echo "$$EUPS_DB_DIR/site/$$f exists; not overwriting" >&2; \
 		else \
-			echo cp $$f $$EUPS_DB_DIR/site; \
-			cp $$f $$EUPS_DB_DIR/site; \
+			echo cp "$$f" "$$EUPS_DB_DIR/site"; \
+			cp "$$f" "$$EUPS_DB_DIR/site"; \
 		fi; \
 	done
 

--- a/tests/testCmd.py
+++ b/tests/testCmd.py
@@ -10,7 +10,7 @@ import os
 import sys
 import unittest
 import re, shutil
-from eups.utils import StringIO
+from eups.utils import StringIO, encodePath
 from testCommon import testEupsStack
 
 import eups.cmd
@@ -131,12 +131,12 @@ doxygen               1.5.7.1    \tcurrent
 eigen                 2.0.0      \tcurrent
 mpich2                1.0.5p4    \tcurrent
 python                2.5.2      \tcurrent
-python                2.6        
+python                2.6        """ """
 tcltk                 8.5a4      \tcurrent
 """.strip()
         outpy = """
    2.5.2      \tcurrent
-   2.6        
+   2.6
 """.strip()
         outcurr = "\n".join(l for l in outpy.split("\n") if l.find('current') >= 0).strip()
         outnews = "\n".join(l for l in outpy.split("\n") if l.find('2.6') >= 0).strip()
@@ -185,13 +185,14 @@ tcltk                 8.5a4      \tcurrent
 
         # test listing of LOCAL products
         self._resetOut()
-        eups.setup("python", productRoot=os.path.join(testEupsStack, "Linux",
-                                                      "python", "2.5.2"))
+        productRoot = os.path.join(testEupsStack, "Linux",
+                                   "python", "2.5.2")
+        eups.setup("python", productRoot=productRoot)
         outwlocal = """
    2.5.2      \tcurrent
-   2.6        
-   LOCAL:%s/Linux/python/2.5.2 \tsetup
-""".strip() % testEupsStack
+   2.6        """ """
+   LOCAL:%s \tsetup
+""".strip() % encodePath(productRoot)
         cmd = eups.cmd.EupsCmd(args="list python".split(), toolname=prog)
         self.assertEqual(cmd.run(), 0)
         self.assertEquals(self.out.getvalue(), outwlocal)
@@ -213,7 +214,7 @@ tcltk                 8.5a4      \tcurrent
         self.assertTrue([l for l in lines if pyuser.match(l)])
 
         self._resetOut()
-        cmd = eups.cmd.EupsCmd(args="uses tcltk -t latest".split(), 
+        cmd = eups.cmd.EupsCmd(args="uses tcltk -t latest".split(),
                                toolname=prog)
         self.assertEqual(cmd.run(), 0)
         self.assertEquals(self.err.getvalue(), "")
@@ -245,8 +246,8 @@ tcltk                 8.5a4      \tcurrent
         table = os.path.join(pdir10, "ups", "newprod.table")
         newprod = os.path.join(self.dbpath,"newprod")
 
-        cmd = "declare newprod 1.0 -r %s -m %s" % (pdir10, table)
-        cmd = eups.cmd.EupsCmd(args=cmd.split(), toolname=prog)
+        cmdargs = ["declare", "newprod", "1.0", "-r", pdir10, "-m", table]
+        cmd = eups.cmd.EupsCmd(args=cmdargs, toolname=prog)
         self.assertEqual(cmd.run(), 0)
         self.assertEquals(self.err.getvalue(), "")
         self.assertEquals(self.out.getvalue(), "")
@@ -293,8 +294,8 @@ tcltk                 8.5a4      \tcurrent
         self.assertFalse(os.path.isdir(newprod))
 
         self._resetOut()
-        cmd = "declare newprod 1.0 -F -r %s -m %s -t current" % (pdir10, table)
-        cmd = eups.cmd.EupsCmd(args=cmd.split(), toolname=prog)
+        cmdargs = ["declare", "newprod", "1.0", "-F", "-r", pdir10, "-m", table, "-t", "current"]
+        cmd = eups.cmd.EupsCmd(args=cmdargs, toolname=prog)
         self.assertEqual(cmd.run(), 0)
         self.assertEquals(self.err.getvalue(), "")
         self.assertEquals(self.out.getvalue(), "")
@@ -348,7 +349,7 @@ tcltk                 8.5a4      \tcurrent
         self.assertTrue(out.find("doxygen") >= 0)
 
         self._resetOut()
-        cmd = eups.cmd.EupsCmd(args="distrib list -f Linux".split(), 
+        cmd = eups.cmd.EupsCmd(args="distrib list -f Linux".split(),
                                toolname=prog)
         self.assertEqual(cmd.run(), 0)
         self.assertEquals(self.err.getvalue(), "")
@@ -399,9 +400,9 @@ class SetupCmdTestCase(unittest.TestCase):
         pdir = os.path.join(testEupsStack, "Linux", "newprod")
         pdir11 = os.path.join(pdir, "1.1")
 
-        cmd = "-r %s newprod" % pdir11
+        cmdargs = ["-r", pdir11, "newprod"]
         hooks.config.Eups.defaultTags = dict(pre=[], post=[]) # disable any defined in the startup.py file
-        cmd = eups.setupcmd.EupsSetup(args=cmd.split(), toolname=prog)
+        cmd = eups.setupcmd.EupsSetup(args=cmdargs, toolname=prog)
         self.assertEqual(cmd.run(), 0)
         
 

--- a/tests/testEups.py
+++ b/tests/testEups.py
@@ -45,7 +45,7 @@ class EupsTestCase(unittest.TestCase):
 
         usercachedir = os.path.join(testEupsStack,"_userdata_","_caches_")
         if os.path.exists(usercachedir):
-            os.system("rm -rf " + usercachedir)
+            os.system('rm -rf "%s"' % usercachedir)
 
         if os.path.exists(self.betachain):  os.remove(self.betachain)
 

--- a/tests/testEupsIntegration/testDyldLibraryPath.sh
+++ b/tests/testEupsIntegration/testDyldLibraryPath.sh
@@ -73,3 +73,7 @@ chmod +x auxTestDyldLibraryPath_csh
 # Test with regular DYLD_LIBRARY_PATH
 (   auxTestDyldLibraryPath_bash "a/b/c" )
 ( ./auxTestDyldLibraryPath_csh  "a/b/c" )
+
+# Test with spaces in input DYLD_LIBRARY_PATH
+( auxTestDyldLibraryPath_bash  "a/b c/d" )
+( ./auxTestDyldLibraryPath_csh "a/b c/d" )

--- a/tests/testEupsIntegration/testSpaces.sh
+++ b/tests/testEupsIntegration/testSpaces.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+#
+# Verify that setup/unsetup works in a local directory with a space
+# in the path. Also attempts to unsetup eups itself.
+#
+
+testpath="`pwd`/space path"
+trap '{ rm -rf "$testpath"; }' EXIT
+rm -rf "$testpath"
+
+# Create dummy EUPS package with empty table file
+mkdir "$testpath"
+mkdir "$testpath/ups"
+touch "$testpath/ups/spaces.table"
+
+# Initialize EUPS
+source "$EUPS_DIR/bin/setups.sh"
+
+cd "$testpath"
+
+setup -k -r .
+if [ $(eups list 2>&1 | grep -c Problem) != "0" ]; then
+  echo Problem detected in eups list
+  exit 1
+fi
+
+unsetup -r .
+unsetup eups
+

--- a/ups/Makefile
+++ b/ups/Makefile
@@ -2,7 +2,7 @@ all :
 	@: no default actions
 
 install :
-	cp eups.table $(EUPS_DIR)/ups
+	cp eups.table "$(EUPS_DIR)/ups"
 
 clean:
 	$(RM) *~ core*

--- a/ups/eups.table.in
+++ b/ups/eups.table.in
@@ -1,6 +1,6 @@
-envPrepend(PATH, ${PRODUCT_DIR}/bin)
-envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
-envAppend(EUPS_PATH, @EUPS_PATH@)
+envPrepend(PATH, "${PRODUCT_DIR}/bin")
+envPrepend(PYTHONPATH, "${PRODUCT_DIR}/python")
+envAppend(EUPS_PATH, "@EUPS_PATH@")
 
-addAlias(setup,   eval `${PRODUCT_DIR}/bin/eups_setup DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH} \"$@\"`);
-addAlias(unsetup, eval `${PRODUCT_DIR}/bin/eups_setup DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH} --unsetup \"$@\"`);
+addAlias(setup,   eval `"${PRODUCT_DIR}/bin/eups_setup" "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" \"$@\"`);
+addAlias(unsetup, eval `"${PRODUCT_DIR}/bin/eups_setup" "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" --unsetup \"$@\"`);

--- a/ups/eups.table.in
+++ b/ups/eups.table.in
@@ -2,5 +2,5 @@ envPrepend(PATH, "${PRODUCT_DIR}/bin")
 envPrepend(PYTHONPATH, "${PRODUCT_DIR}/python")
 envAppend(EUPS_PATH, "@EUPS_PATH@")
 
-addAlias(setup,   eval `"${PRODUCT_DIR}/bin/eups_setup" "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" \"$@\"`);
-addAlias(unsetup, eval `"${PRODUCT_DIR}/bin/eups_setup" "DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}" --unsetup \"$@\"`);
+addAlias(setup,   eval `\"${PRODUCT_DIR}/bin/eups_setup\" DYLD_LIBRARY_PATH=\"${DYLD_LIBRARY_PATH}\" \"$@\"`);
+addAlias(unsetup, eval `\"${PRODUCT_DIR}/bin/eups_setup\" DYLD_LIBRARY_PATH=\"${DYLD_LIBRARY_PATH}\" --unsetup \"$@\"`);


### PR DESCRIPTION
Previous patches enabled spaces in paths for local setups. These patches enable spaces in paths for installation of EUPS.