### PR TITLE
Supply the reason for URL failure

### DIFF
--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -976,10 +976,10 @@ class WebTransporter(Transporter):
                     url = urlopen(self.loc)
                     out = open(filename, 'wb')
                     out.write(url.read())
-                except HTTPError:
-                    raise RemoteFileNotFound("Failed to open URL %s" % self.loc)
-                except URLError:
-                    raise ServerNotResponding("Failed to contact URL %s" % self.loc)
+                except HTTPError as e:
+                    raise RemoteFileNotFound("Failed to open URL %s (%s)" % (self.loc, e.reason))
+                except URLError as e:
+                    raise ServerNotResponding("Failed to contact URL %s (%s)" % (self.loc, e.reason))
                 except KeyboardInterrupt:
                     raise EupsException("^C")
             finally: 
@@ -1054,10 +1054,10 @@ class WebTransporter(Transporter):
 
             return p.files
 
-          except HTTPError:
-            raise RemoteFileNotFound("Failed to open URL %s" % self.loc)
-          except URLError:
-            raise ServerNotResponding("Failed to contact URL %s" % self.loc)
+          except HTTPError as e:
+            raise RemoteFileNotFound("Failed to open URL %s (%s)" % (self.loc, e.reason))
+          except URLError as e:
+            raise ServerNotResponding("Failed to contact URL %s (%s)" % (self.loc, e.reason))
           except KeyboardInterrupt:
             raise EupsException("^C")
         finally: 


### PR DESCRIPTION
It can be confusing to report the "Failed to contact URL" message
without context as in some cases wget and curl can work fine
but urllib complains. Providing the reason may help.