### PR TITLE
fix Makefile EUPS_DB path generation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,7 +14,7 @@ EUPS_PATH = @EUPS_PATH@
 EUPS_DIR = @EUPS_DIR@
 SETUP_ALIASES = @SETUP_ALIASES@
 EUPS_PYTHON = @EUPS_PYTHON@
-EUPS_DB = $(shell perl -e 'foreach $$d (split(":","$(EUPS_PATH)")) { print "$$d/ups_db\n"}')
+EUPS_DB = $(firstword $(subst :, ,$(EUPS_PATH)))
 #
 export prefix EUPS_PATH EUPS_DIR SETUP_ALIASES EUPS_PYTHON
 #


### PR DESCRIPTION
Due to the way perl was being used to parse the EUPS_PATH, any perl
variable sigils present in EUPS_PATH would result in incorrect path
generation for EUPS_DB. Eg.,

    $ perl -e 'foreach $d (split(":","/foo@bar")) { print "$d/ups_db\n"}'
    /foo/ups_db

This was particularly problematic when running under jenkins, as
`<path>/<name>@<n>` is used to isolate concurrent builds of the same job
on a single build slave.