### PR TITLE
Use a utility function to check for strings

### DIFF
--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -50,7 +50,7 @@ class Eups(object):
         if not path:
             path = os.environ.get("EUPS_PATH", [])
 
-        if isinstance(path, str):
+        if utils.is_string(path):
             path = path.split(":")
 
         if dbz:
@@ -206,12 +206,12 @@ class Eups(object):
         self.cmdName = cmdName
 
         # set the valid setup types
-        if isinstance(validSetupTypes, str):
+        if utils.is_string(validSetupTypes):
             validSetupTypes = validSetupTypes.split()
         self._validSetupTypes = validSetupTypes
         if self._validSetupTypes is None:
             self._validSetupTypes = hooks.config.Eups.setupTypes
-            if isinstance(self._validSetupTypes, str):
+            if utils.is_string(self._validSetupTypes):
                 utils.deprecated("Setting config.Eups.setupTypes with a string is deprecated; " +
                                  "please use a list.", self.quiet)
                 self._validSetupTypes.split()
@@ -220,7 +220,7 @@ class Eups(object):
         #
         if setupType in (None, ""):
             self.setupType = []
-        elif isinstance(setupType, str):
+        elif utils.is_string(setupType):
             if re.search(r"[\s,]", setupType):
                 self.setupType = re.split(r"[\s,]+", setupType)
             else:
@@ -335,7 +335,7 @@ class Eups(object):
         if not isinstance(fallbackList, dict):
             fallbackList = {None : fallbackList}
         for flavor, fbl in fallbackList.items():
-            if isinstance(fbl, str):
+            if utils.is_string(fbl):
                 fbl = fbl.split()
             utils.Flavor().setFallbackFlavors(flavor, fbl)
         # 
@@ -356,7 +356,7 @@ class Eups(object):
             (["commandLine", "keep", "path", "setup", "type",
               "version", "version!", "versionExpr", "warn",], Tags.pseudo),
             ]:
-            if isinstance(tags, str):
+            if utils.is_string(tags):
                 tags = tags.split()
             for tag in tags:
                 try:
@@ -376,7 +376,7 @@ class Eups(object):
         for tags in pt:
             if not tags:
                 tags = hooks.config.Eups.preferredTags
-            if isinstance(tags, str):
+            if utils.is_string(tags):
                 tags = tags.split()
 
             for t in tags:
@@ -391,7 +391,7 @@ class Eups(object):
         self._reservedTags = hooks.config.Eups.reservedTags
         if self._reservedTags is None:
             self._reservedTags = []
-        elif isinstance(self._reservedTags, str):
+        elif utils.is_string(self._reservedTags):
             self._reservedTags = self._reservedTags.split()
         #
         # Some tags are always reserved
@@ -668,7 +668,7 @@ The what argument tells us what sort of state is expected (allowed values are de
 
     def _kindlySetPreferredTags(self, tags, strict=False):
 
-        if isinstance(tags, str):
+        if utils.is_string(tags):
             tags = tags.split()
         if not isinstance(tags, list):
             raise TypeError("Eups.setPreferredTags(): arg not a list")
@@ -831,7 +831,7 @@ The what argument tells us what sort of state is expected (allowed values are de
             flavor = self.flavor
         if eupsPathDirs is None:
             eupsPathDirs = self.path
-        if isinstance(eupsPathDirs, str):
+        if utils.is_string(eupsPathDirs):
             eupsPathDirs = [eupsPathDirs]
 
         product, vroReason = None, None
@@ -1069,10 +1069,10 @@ The what argument tells us what sort of state is expected (allowed values are de
             flavor = self.flavor
         if eupsPathDirs is None:
             eupsPathDirs = self.path
-        if isinstance(eupsPathDirs, str):
+        if utils.is_string(eupsPathDirs):
             eupsPathDirs = [eupsPathDirs]
 
-        if isinstance(version, str):
+        if utils.is_string(version):
             if self.isLegalRelativeVersion(version):  # raises exception if bad syntax used
                 return self._findPreferredProductByExpr(name, version, 
                                                         eupsPathDirs, flavor, 
@@ -1134,7 +1134,7 @@ The what argument tells us what sort of state is expected (allowed values are de
             flavor = self.flavor
         if eupsPathDirs is None:
             eupsPathDirs = self.path
-        if isinstance(eupsPathDirs, str):
+        if utils.is_string(eupsPathDirs):
             eupsPathDirs = [eupsPathDirs]
 
         try:
@@ -1158,7 +1158,7 @@ The what argument tells us what sort of state is expected (allowed values are de
             flavor = self.flavor
         if eupsPathDirs is None:
             eupsPathDirs = self.path
-        if isinstance(eupsPathDirs, str):
+        if utils.is_string(eupsPathDirs):
             eupsPathDirs = [eupsPathDirs]
 
         if tag.name == "latest":
@@ -1227,7 +1227,7 @@ The what argument tells us what sort of state is expected (allowed values are de
             flavor = self.flavor
         if eupsPathDirs is None:
             eupsPathDirs = self.path
-        if isinstance(eupsPathDirs, str):
+        if utils.is_string(eupsPathDirs):
             eupsPathDirs = [eupsPathDirs]
         #
         # Read file seeing if it lists a desired version of product name
@@ -1804,7 +1804,7 @@ The what argument tells us what sort of state is expected (allowed values are de
         @param implicitProduct  True iff product is setup due to being specified in implicitProducts
         """
 
-        if isinstance(versionName, str) and versionName.startswith(Product.LocalVersionPrefix):
+        if utils.is_string(versionName) and versionName.startswith(Product.LocalVersionPrefix):
             productRoot = versionName[len(Product.LocalVersionPrefix):]
 
         if productRoot is None:
@@ -2653,7 +2653,7 @@ The what argument tells us what sort of state is expected (allowed values are de
                 
         if tag:
             # we just want to update the tag
-            if isinstance(tag, str):
+            if utils.is_string(tag):
                 tag = [self.tags.getTag(tag)]
 
             if verbose:
@@ -3383,7 +3383,7 @@ The what argument tells us what sort of state is expected (allowed values are de
                               will be remembered only for the current 
                               Eups instance.  
         """
-        if isinstance(tags, str):
+        if utils.is_string(tags):
             tags = tags.split()
 
         stacktags = None
@@ -3454,7 +3454,7 @@ The what argument tells us what sort of state is expected (allowed values are de
         """
         if not path:
             path = self.path
-        elif isinstance(path, str):
+        elif utils.is_string(path):
             path = [path]
 
         preferred = currentTypesToTry

--- a/python/eups/Product.py
+++ b/python/eups/Product.py
@@ -58,11 +58,11 @@ class Product(object):
 
     def __init__(self, name, version, flavor=None, dir=None, table=None, 
                  tags=None, db=None, noInit=None, ups_dir=None):
-        if (name and not isinstance(name, str)) or isinstance(dir,bool) or noInit is not None:
+        if (name and not utils.is_string(name)) or isinstance(dir,bool) or noInit is not None:
             import inspect
             caller = (inspect.stack(context=2))[1]
             reason = "unknown"
-            if name and not isinstance(name, str):
+            if name and not utils.is_string(name):
                 reason = "name is '{0}' ({1}) and not str".format(name, type(name))
             elif isinstance(dir, bool):
                 reason = "dir is bool"
@@ -260,7 +260,7 @@ class Product(object):
 
         dosub = list(data.keys())
         if skip:
-            if isinstance(skip, str):
+            if utils.is_string(skip):
                 skip = skip.split()
             dosub = [n for n in dosub if n not in skip]
 

--- a/python/eups/app.py
+++ b/python/eups/app.py
@@ -55,7 +55,7 @@ def printProducts(ostrm, productName=None, versionName=None, eupsenv=None,
     if not eupsenv:
         eupsenv = Eups()
     if tags:
-        if isinstance(tags, str):
+        if utils.is_string(tags):
             tags = tags.split()
         checkTagsList(eupsenv, tags)
     elif setup and not dependencies:
@@ -540,7 +540,7 @@ def clearCache(path=None, flavors=None, inUserDir=False, verbose=0):
     """
     if path is None:
         path = os.environ["EUPS_PATH"]
-    if isinstance(path, str):
+    if utils.is_string(path):
         path = path.split(":")
 
     userDataDir = utils.defaultUserDataDir()
@@ -549,7 +549,7 @@ def clearCache(path=None, flavors=None, inUserDir=False, verbose=0):
     if not inUserDir:
         userDataDir = None              # Clear the system cache, not the one in userDataDir
 
-    if isinstance(flavors, str):
+    if utils.is_string(flavors):
         flavors = flavors.split()
 
     for p in path:
@@ -575,7 +575,7 @@ def clearCache(path=None, flavors=None, inUserDir=False, verbose=0):
 def listCache(path=None, verbose=0, flavor=None):
     if path is None:
         path = os.environ["EUPS_PATH"]
-    if isinstance(path, str):
+    if utils.is_string(path):
         path = path.split(":")
 
     if not flavor:
@@ -663,7 +663,7 @@ def setup(productName, version=None, prefTags=None, productRoot=None,
         if version:
             eupsenv.selectVRO(versionName=version)
 
-    if isinstance(prefTags, str):
+    if utils.is_string(prefTags):
         prefTags = prefTags.split()
     elif isinstance(prefTags, Tag):
         prefTags = [prefTags]

--- a/python/eups/cmd.py
+++ b/python/eups/cmd.py
@@ -325,7 +325,7 @@ Common"""
             
         if hasattr(opts, "tag") and opts.tag:
             tag = opts.tag
-            if isinstance(tag, str):
+            if utils.is_string(tag):
                 tag = [tag]
         else:
             tag = None

--- a/python/eups/db/Database.py
+++ b/python/eups/db/Database.py
@@ -7,7 +7,7 @@ from .ChainFile import ChainFile
 import eups.tags
 from eups.Product import Product
 from eups.exceptions import UnderSpecifiedProduct, ProductNotFound, TableFileNotFound
-from eups.utils import xrange, cmp_or_key
+from eups.utils import xrange, cmp_or_key, is_string
 
 versionFileExt = "version"
 versionFileTmpl = "%s." + versionFileExt
@@ -529,7 +529,7 @@ class _Database(object):
         if not os.path.exists(pdir):
             raise ProductNotFound(productName, stack=self.dbpath);
 
-        if isinstance(tag, str):
+        if is_string(tag):
             tag = eups.tags.Tag(tag)
 
         pdirs = []
@@ -577,7 +577,7 @@ class _Database(object):
                                 If None, tag all available flavors.  
         """
 
-        if isinstance(tag, str):
+        if is_string(tag):
             tag = eups.tags.Tag(tag)
 
         vf = VersionFile(self._versionFile(productName, version))

--- a/python/eups/db/VersionFile.py
+++ b/python/eups/db/VersionFile.py
@@ -184,7 +184,7 @@ class VersionFile(object):
 
         dosub = list(data.keys())
         if skip:
-            if isinstance(skip, str):
+            if eups.utils.is_string(skip):
                 skip = skip.split()
             dosub = [n for n in dosub if n not in skip]
 

--- a/python/eups/distrib/Repositories.py
+++ b/python/eups/distrib/Repositories.py
@@ -59,7 +59,7 @@ class Repositories(object):
         @param log        the destination for status messages (default:
                             sys.stderr)
         """
-        if isinstance(pkgroots, str):
+        if utils.is_string(pkgroots):
             pkgroots = [p.strip() for p in pkgroots.split("|")]
         if not allowEmptyPkgroot and len(pkgroots) == 0:
             raise EupsException("No package servers to query; set -r or $EUPS_PKGROOT")
@@ -323,7 +323,7 @@ class Repositories(object):
                             defaults to False).
         """
         if alsoTag is not None:
-            if isinstance(alsoTag, str):
+            if utils.is_string(alsoTag):
                 alsoTag = [self.eups.tags.getTag(t) for t in alsoTag.split()]
             elif isinstance(alsoTag, Tag):
                 alsoTag = [alsoTag]

--- a/python/eups/distrib/Repository.py
+++ b/python/eups/distrib/Repository.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, print_function
 import sys
 import eups
 from eups.tags      import Tag, TagNotRecognized
-from eups.utils     import Flavor, isDbWritable, cmp_or_key, xrange
+from eups.utils     import Flavor, isDbWritable, cmp_or_key, xrange, is_string
 from eups.exceptions import EupsException, ProductNotFound
 from .server         import ServerConf, Manifest, Mapping, TaggedProductList
 from .server         import LocalTransporter
@@ -98,7 +98,7 @@ class Repository(object):
         # of available products will be used.
         self._alwaysQueryServer = False
         if "alwaysQueryServer" in self.options:
-            if isinstance(self.options["alwaysQueryServer"], str):
+            if is_string(self.options["alwaysQueryServer"]):
                 self.options["alwaysQueryServer"] = \
                     self.options["alwaysQueryServer"].upper()
                 if "TRUE".startswith(self.options["alwaysQueryServer"]):
@@ -318,7 +318,7 @@ class Repository(object):
                 for flav in flavs:
                     if version is None:
                         out.extend( (prod, v, flav) for v in self._pkgList[prod][flav] )
-                    elif version and isinstance(version, str):
+                    elif version and is_string(version):
                         if version not in self._pkgList[prod][flav]:
                             continue
                         out.append( (prod, version, flav) )

--- a/python/eups/distrib/pacman.py
+++ b/python/eups/distrib/pacman.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import sys, os
 from . import Distrib as eupsDistrib
 from . import server as eupsServer
+from eups import utils
 
 class Distrib(eupsDistrib.DefaultDistrib):
     """A class to encapsulate Pacman-based product distribution
@@ -71,7 +72,7 @@ class Distrib(eupsDistrib.DefaultDistrib):
                 return False
 
             msg = "Illegal value for Option 'pacmanCache': "
-            if not isinstance(self.options['pacmanCache'], str):
+            if not utils.is_string(self.options['pacmanCache']):
                 print(msg + self.options['pacmanCache'], file=self.log)
                 return False
 

--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -137,7 +137,7 @@ class DistribServer(object):
         """
         if tags is None:
             tags = self.getTagNames()
-        if isinstance(tags, str):
+        if utils.is_string(tags):
             tags = tags.split()
 
         out = []
@@ -1463,7 +1463,7 @@ class Dependency(object):
     def __init__(self, product, version, flavor, tablefile, instDir, distId,
                  isOptional=False, shouldRecurse=False, extra=None):
         self.product = product
-        if not isinstance(version, str):
+        if not utils.is_string(version):
             if isinstance(version, type):
                 version = version()
             else:

--- a/python/eups/hooks.py
+++ b/python/eups/hooks.py
@@ -28,7 +28,7 @@ def defineProperties(names, parentName=None):
                           Provide this if this is defining a non-top-level
                           property.  
     """
-    if isinstance(names, str):
+    if utils.is_string(names):
         names = names.split()
     return utils.ConfigProperty(names, parentName)
 

--- a/python/eups/stack/ProductStack.py
+++ b/python/eups/stack/ProductStack.py
@@ -262,7 +262,7 @@ class ProductStack(object):
         """
         if not flavors:
             flavors = self.getFlavors()
-        if isinstance(flavors, str):
+        if utils.is_string(flavors):
             flavors = [flavors]
         for flavor in flavors:
             file = self._persistPath(flavor)
@@ -587,12 +587,12 @@ class ProductStack(object):
                                 None, cache for all products
         @param flavors       the flavors of products to cache tables fo.  
         """
-        if productName and isinstance(productName, str):
+        if productName and utils.is_string(productName):
             productName = productName.split()
 
         if not flavors:
             flavors = self.getFlavors()
-        elif isinstance(flavors, str):
+        elif utils.is_string(flavors):
             flavors = flavors.split()
         
         for flavor in flavors:

--- a/python/eups/table.py
+++ b/python/eups/table.py
@@ -1033,7 +1033,7 @@ class Action(object):
                             msg += ": %s" % reason
                         print("            %s%s" % (recursionDepth*" ", msg), file=utils.stdinfo)
                 else:
-                    if isinstance(reason, str):
+                    if utils.is_string(reason):
                         utils.debug("reason is a str", reason)
 
                     reason.msg = "in file %s: %s" % (self.tableFile, reason)
@@ -1082,7 +1082,7 @@ class Action(object):
                             msg += ": %s" % reason
                         print("            %s%s" % (recursionDepth*" ", msg), file=utils.stdinfo)
                 else:
-                    if isinstance(reason, str):
+                    if utils.is_string(reason):
                         utils.debug("reason is a str", reason)
 
                     reason.msg = "in file %s: %s" % (self.tableFile, reason)

--- a/python/eups/tags.py
+++ b/python/eups/tags.py
@@ -43,7 +43,7 @@ class Tags(object):
             if group not in self.bygrp:
                 self.bygrp[group] = []
 
-        if isinstance(globals, str):
+        if utils.is_string(globals):
             globals = globals.split()
         if globals:
             for tag in globals:
@@ -62,7 +62,7 @@ class Tags(object):
                          type Tag
         @return bool 
         """
-        if isinstance(tag, str) and tag.find(':') >= 0:
+        if utils.is_string(tag) and tag.find(':') >= 0:
             # parse a qualified name
             tag = Tag.parse(tag)
         return (self.groupFor(tag) is not None)
@@ -118,7 +118,7 @@ class Tags(object):
         if tag is None:
             return None
 
-        if isinstance(tag, str) and tag != ":" and tag.find(':') >= 0:
+        if utils.is_string(tag) and tag != ":" and tag.find(':') >= 0:
             # parse a qualified name
             tag = Tag.parse(tag)
         group = self.groupFor(tag)
@@ -148,7 +148,7 @@ class Tags(object):
         if group is None:
             group = self.global_
 
-        if isinstance(name, str):
+        if utils.is_string(name):
             owner = None
         else:
             name, owner = name
@@ -262,7 +262,7 @@ class Tags(object):
                             stacks) given either as a list of strings 
                             or a single colon-separated string.
         """
-        if isinstance(eupsPath, str):
+        if utils.is_string(eupsPath):
             eupsPath = eupsPath.split(':')
         if not isinstance(eupsPath, list):
             raise TypeError("Tags.loadFromEupsPath(): eupsPath not a str/list:"

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -35,6 +35,9 @@ if sys.version_info[0] == 2:
 
     def decode(string, encoding):
         return string
+
+    def is_string(string):
+        return isinstance(string, basestring)
 else:
     # Python 3.x versions
     import io as StringIO
@@ -65,6 +68,9 @@ else:
 
     def decode(string, encoding):
         return string.decode(encoding)
+
+    def is_string(string):
+        return isinstance(string, str)
 
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
@@ -300,7 +306,7 @@ def findWritableDb(pathdirs, ups_db):
     """return the first directory in the eups path that the user can install 
     stuff into
     """
-    if isinstance(pathdirs, str):
+    if is_string(pathdirs):
         pathdirs = pathdirs.split(':')
     if not isinstance(pathdirs, list):
         raise TypeError("findWritableDb(): arg is not list or string: " + 


### PR DESCRIPTION
Sometimes we can end up with unicode strings if the database has been created on Python 3 but accessed on Python 2. This causes some strange behavior as many of the checks for strings were assuming only "str". To be consistent across versions those checks are now different on Python 2 and Python 3. On Python 3 `str` is the only option but on Python 2 the comparison is now with `basestring`.