### PR TITLE
add 's' to TAG_PATTERN

### DIFF
--- a/bin/pkgautoversion
+++ b/bin/pkgautoversion
@@ -131,7 +131,7 @@ git_version()
 	fi
 
 	local REF=${1:-HEAD}
-	local TAG_PATTERN=${2:-'[0-9]*'}	# The pattern defining eligible tags
+	local TAG_PATTERN=${2:-'[0-9,s]*'}	# The pattern defining eligible tags
 
 	# Check if this ref is already an annotated tag matching the tag pattern; if yes, we're done.
 	if [[ "$REF" == $TAG_PATTERN && $(git cat-file -t "$REF" 2>/dev/null) == tag ]]; then


### PR DESCRIPTION
This will allow eups to correctly detect and list
sims version tags (which look like 'sims_#.#.#')
in the ups_db.

There has been some confusion among sims users that, when they `eups distrib install` the latest version of lsst_sims, `eups list` displays the sims packages by their github SHA, rather than by their version tag.  This PR should fix that behavior.