### PR TITLE
Add missing cmp import for Python 3 (fix for #111)

### DIFF
--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -3277,6 +3277,9 @@ The what argument tells us what sort of state is expected (allowed values are de
     def _remove(self, productName, versionName, recursive, checkRecursive, topProduct, topVersion, userInfo):
         """The workhorse for remove"""
 
+        if productName == hooks.config.Eups.defaultProduct.get("name", "toolchain"):
+            return []
+
         product = self.getProduct(productName, versionName)  # can raise ProductNotFound
         deps = [[product, False, 0]]
         if recursive:

--- a/python/eups/Uses.py
+++ b/python/eups/Uses.py
@@ -3,7 +3,7 @@ the Uses class -- a class for tracking product dependencies (used by the remove(
 function).  
 """
 import re
-from .utils import cmp_or_key
+from .utils import cmp_or_key, cmp
 
 #
 # Cache for the Uses tree


### PR DESCRIPTION
This seems to be necessary to use `eups remove` on Python 3.
