### PR TITLE
Implement a partial locking fix.

### DIFF
--- a/python/eups/lock.py
+++ b/python/eups/lock.py
@@ -103,7 +103,7 @@ def takeLocks(cmdName, path, lockType, nolocks=False, ntry=10, verbose=0):
                         if not os.path.exists(lockDir):
                             if verbose:
                                 print("Unable to lock %s; proceeding with trepidation" % d, file=utils.stdwarn)
-                            return []
+                            return locks
 
                 if not makeLock:
                     continue


### PR DESCRIPTION
If a user has multiple stacks in `EUPS_PATH`, one or more of which are writable followed by at least one that is not writable, the failure to create a lock directory for a shared lock in the non-writable stack will wipe out any memory of successfully created locks in the writable stacks.  This means that the locks in the writable stacks never get cleaned up.  This change at least preserves the memory of the successfully created locks, although it doesn't try to lock any writable stacks after the non-writable one in `EUPS_PATH`.