### PR TITLE
BUG make sure python packages only install themselves

### DIFF
--- a/lib/eupspkg.sh
+++ b/lib/eupspkg.sh
@@ -853,7 +853,17 @@ default_install()
 		PYDEST="$PREFIX/lib/python"
 		mkdir -p "$PYDEST"
 		# eval is needed to allow $PYSETUP_INSTALL_OPTIONS to include double quotes
-		PYTHONPATH="$PYDEST:$PYTHONPATH" eval python setup.py install $PYSETUP_INSTALL_OPTIONS
+		{
+			# the extra options here prevent the installation of dependencies via
+			# eups - the installation will error with the name of the package that is needed
+			# this only works for setuptools-based packages
+			PYTHONPATH="$PYDEST:$PYTHONPATH" \
+				eval python setup.py install --single-version-externally-managed --record record.txt  $PYSETUP_INSTALL_OPTIONS
+		} || {
+			# this block catches distutils-only packages that don't install their
+			# dependencies anyways
+			PYTHONPATH="$PYDEST:$PYTHONPATH" eval python setup.py install $PYSETUP_INSTALL_OPTIONS
+		}
 		evil_setuptools_pth_fix "$PYDEST"
 	else
 		# just copy everything, except for the ups directory


### PR DESCRIPTION
Currently, `eups` was allowing python packages to install their own dependencies via `pypi` on-the-fly. This behavior creates unpredictable installations since any dependences should be declared explicitly in `eups` or installed by the user separately. 

This PR adds two extra options for python installations that force the code to error if a dependence is not found. Note that these options are present only for `setuptools`-based python packages. For old `distutils`-based ones, the current script worked fine. Thus I added a fallback to the old installation via bash's `||` operator.

A better solution might be to use `pip` to install the local python packages. In that case, you can simply run `pip install --no-deps .` to install a package in your current working dir. I'm happy to switch to this, but then we would need to make sure `eups` has access to the right `pip` when running, which is potentially non-trivial given the variety of people's python setups.