### PR TITLE
Fix `eups list -s -d` to not print a product even if none are setup

### DIFF
--- a/python/eups/app.py
+++ b/python/eups/app.py
@@ -88,7 +88,8 @@ def printProducts(ostrm, productName=None, versionName=None, eupsenv=None,
         eupsenv.setup(productName, versionName, productRoot=os.path.abspath(productDir))
         setup = True                    # only list this version
 
-    productList = eupsenv.findProducts(productName, versionName, tags)
+    productList = eupsenv.getSetupProducts(productName) if setup else \
+                  eupsenv.findProducts(productName, versionName, tags)
     if not productList:
         if productName:
             msg = productName
@@ -105,11 +106,13 @@ def printProducts(ostrm, productName=None, versionName=None, eupsenv=None,
         recursionDepth, indent = 0, ""
 
         if len(productList) > 1:
-            if setup:
-                productList = eupsenv.getSetupProducts(productName)
+            if productName:
+                raise EupsException("Please choose the version of %s that you want (%s)" %
+                                    (productName, ", ".join(p.version for p in productList)))
             else:
-                raise EupsException("Please choose the version you want listed (%s)" %
-                                    (", ".join(p.version for p in productList)))
+                raise EupsException("Please choose the product and maybe version that you want (%s)" %
+                                    (", ".join(("%s:%s" % (p.name, p.version)) for p in productList)))
+
     else:
         if topological:
             raise EupsException("--topological only makes sense with --dependencies")
@@ -136,6 +139,9 @@ def printProducts(ostrm, productName=None, versionName=None, eupsenv=None,
 
     if dependencies:
         recursionDepth = 0
+
+        if not productList:
+            return 0
 
         product = productList[0]
 

--- a/python/eups/tags.py
+++ b/python/eups/tags.py
@@ -218,6 +218,7 @@ class Tags(object):
                           from configured location.
         """
 
+        fd = None
         try:
             fd = open(file)
             if group not in self.bygrp:
@@ -228,7 +229,8 @@ class Tags(object):
                 line = [t for t in line.split() if t not in self.bygrp[group]]
                 self.bygrp[group].extend(line)
         finally:
-            fd.close()
+            if fd:
+                fd.close()
 
         return [self.getTag(t) for t in self.bygrp[group]]
 


### PR DESCRIPTION
A bit of an edge case as accidentally things worked if more than one product was declared.
