### PR TITLE
DM-32075: Fix versions returned when ref is a tag.

### DIFF
--- a/bin/pkgautoversion
+++ b/bin/pkgautoversion
@@ -144,7 +144,7 @@ git_version()
 	# interpreted as dot-delimited tuples):
 
 	# get a list of annotated tags pointing to $REF
-	TAGS=( $(for tag in $(git tag -l "$TAG_PATTERN" --points-at $REF); do [[ $(git cat-file -t $tag) == tag ]] && echo -n "$tag "; done) )
+	TAGS=( $(for tag in $(git tag -l "$TAG_PATTERN" --points-at $(git rev-parse "$REF^{commit}") ); do [[ $(git cat-file -t $tag) == tag ]] && echo -n "$tag "; done) )
 	local RES
 	if [[ ! -z $TAGS ]]; then
 		# Tag found. Use the tag as version


### PR DESCRIPTION
`--points-at` returns only the tag itself (if it matches the pattern) when given a tag as its object as opposed to the desired list of all (pattern-matched) tags pointing to the same commit.