### PR TITLE
DM-42570: Allow os.makedirs to work if the directory already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,6 @@ bin/setups.zsh
 TAGS
 autom4te.cache
 eups_impl.py
-eups
+bin/eups
 bin/eups_setup
 bin/eups_setup_impl.py

--- a/python/eups/Eups.py
+++ b/python/eups/Eups.py
@@ -513,7 +513,7 @@ The what argument tells us what sort of state is expected (allowed values are de
     def _makeUserCacheDir(self, eupsPathDir):
         cachedir = self._userStackCache(eupsPathDir)
         if cachedir and not os.path.exists(cachedir):
-            os.makedirs(cachedir)
+            os.makedirs(cachedir, exist_ok=True)
             try:
                 readme = open(os.path.join(cachedir,"README"), "w")
                 try:
@@ -1459,7 +1459,7 @@ The what argument tells us what sort of state is expected (allowed values are de
 
         if not os.path.isdir(upsDB):
             if create:
-                os.makedirs(upsDB)
+                os.makedirs(upsDB, exist_ok=True)
 
         if not os.path.isdir(upsDB):
             if noRaise:
@@ -2414,7 +2414,7 @@ The what argument tells us what sort of state is expected (allowed values are de
         if self.isUserTag(tag):
             ups_db = self.getUpsDB(self.userDataDir)
             if not os.path.isdir(ups_db):
-                os.makedirs(ups_db)
+                os.makedirs(ups_db, exist_ok=True)
             eupsPathDir = self.userDataDir
 
         if not eupsPathDir:
@@ -2719,7 +2719,7 @@ The what argument tells us what sort of state is expected (allowed values are de
                 else:
                     if self.verbose > 1:
                         print("mkdir -p %s" % (dirName), file=utils.stdinfo)
-                    os.makedirs(dirName)
+                    os.makedirs(dirName, exist_ok=True)
 
             if not (os.path.exists(pathOut) and os.path.samefile(fileNameIn, pathOut)):
                 if self.noaction:

--- a/python/eups/cmd.py
+++ b/python/eups/cmd.py
@@ -2615,7 +2615,7 @@ class DistribCreateCmd(EupsCmd):
                     break
         elif not os.path.exists(self.opts.serverDir):
             self.err("Server directory %s does not exist; creating " % self.opts.serverDir)
-            os.makedirs(self.opts.serverDir)
+            os.makedirs(self.opts.serverDir, exist_ok=True)
         elif not utils.isDbWritable(self.opts.serverDir):
             self.err("Server directory %s is not writable: " % self.opts.serverDir)
             return 3

--- a/python/eups/db/Database.py
+++ b/python/eups/db/Database.py
@@ -618,7 +618,7 @@ class _Database(object):
             pdir = self._productDir(productName, writeableDB)
 
             if not os.path.exists(pdir):
-                os.makedirs(pdir)
+                os.makedirs(pdir, exist_ok=True)
         else:
             pdir = self._productDir(productName)
 

--- a/python/eups/distrib/Distrib.py
+++ b/python/eups/distrib/Distrib.py
@@ -157,7 +157,7 @@ class Distrib(object):
         @param serverDir    the directory to initialize
         """
         if not os.path.exists(serverDir):
-            os.makedirs(serverDir)
+            os.makedirs(serverDir, exist_ok=True)
 
     def createPackage(self, serverDir, product, version, flavor=None, overwrite=False):
         """Write a package distribution into server directory tree and
@@ -648,7 +648,7 @@ class DefaultDistrib(Distrib):
         for dir in "manifests tables".split():
             dir = os.path.join(serverDir, dir)
             if not os.path.exists(dir):
-                os.makedirs(dir)
+                os.makedirs(dir, exist_ok=True)
 
                 # set group owner ship and permissions, if desired
                 self.setGroupPerms(dir)
@@ -764,7 +764,7 @@ class DefaultDistrib(Distrib):
         out = self.getManifestPath(serverDir, product, version, self.flavor)
         mandir = os.path.dirname(out)
         if not os.path.exists(mandir):
-	        os.makedirs(mandir)
+	        os.makedirs(mandir, exist_ok=True)
 
         man = server.Manifest(product, version, self.Eups,
                        verbosity=self.verbose-1, log=self.log)

--- a/python/eups/distrib/Repositories.py
+++ b/python/eups/distrib/Repositories.py
@@ -859,7 +859,7 @@ class Repositories(object):
                     tablefile = open(tablefile, "r")
                 else:
                     if upsdir and not os.path.exists(upsdir):
-                        os.makedirs(upsdir)
+                        os.makedirs(upsdir, exist_ok=True)
                     tablefile = \
                               repos.distServer.getFileForProduct(mprod.tablefile,
                                                                  mprod.product,
@@ -909,7 +909,7 @@ class Repositories(object):
         # Can we write to that directory?
         #
         try:
-            os.makedirs(buildRoot)      # make sure it exists if we have the power to do so
+            os.makedirs(buildRoot, exist_ok=True)  # make sure it exists if we have the power to do so
         except OSError:                 # already exists, or failed; we don't care which
             pass
 
@@ -927,7 +927,7 @@ class Repositories(object):
                     buildRoot = bd
                 else:
                     try:
-                        os.makedirs(bd)
+                        os.makedirs(bd, exist_ok=True)
                     except Exception as e:
                         pass
                     else:
@@ -954,7 +954,7 @@ class Repositories(object):
         """
         dir = self.getBuildDirFor(productRoot, product, version, options, flavor)
         if not os.path.exists(dir):
-            os.makedirs(dir)
+            os.makedirs(dir, exist_ok=True)
         return dir
 
     def cleanBuildDirFor(self, productRoot, product, version, options=None,

--- a/python/eups/distrib/builder.py
+++ b/python/eups/distrib/builder.py
@@ -214,7 +214,7 @@ DIST_URL = %%(base)s/builds/%%(path)s
         builderDir = os.path.join(serverDir, "builds")
         if not os.path.isdir(builderDir):
             try:
-                os.makedirs(builderDir)
+                os.makedirs(builderDir, exist_ok=True)
             except:
                 raise RuntimeError("Failed to create %s" % (builderDir))
 

--- a/python/eups/distrib/eupspkg.py
+++ b/python/eups/distrib/eupspkg.py
@@ -833,7 +833,7 @@ TAGLIST_DIR = tags
             productsDir = os.path.join(serverDir, "products")
             if not os.path.isdir(productsDir):
                 try:
-                    os.makedirs(productsDir)
+                    os.makedirs(productsDir, exist_ok=True)
                 except:
                     raise RuntimeError("Failed to create %s" % (productsDir))
 

--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -391,7 +391,7 @@ class DistribServer(object):
         # make sure we can write to destination
         parent = os.path.dirname(filename)
         if parent and not os.path.isdir(parent):
-            os.makedirs(parent)
+            os.makedirs(parent, exist_ok=True)
 
         trx.cacheToFile(filename, noaction=noaction) # this is not a cache! It's "copy to local file"
 
@@ -2112,7 +2112,7 @@ class ServerConf(object):
                 # make sure the cache directory exists
                 pdir = os.path.dirname(cached)
                 if not os.path.exists(pdir):
-                    os.makedirs(pdir)
+                    os.makedirs(pdir, exist_ok=True)
                 if self.verbose > 1 and self.base != "/dev/null" and not os.path.exists(cached):
                     print("Caching configuration for %s as %s" % (self.base, cached), file=self.log)
 
@@ -2188,7 +2188,7 @@ class ServerConf(object):
                 configDir = os.path.dirname(configFile)
                 try:
                     if not os.path.exists(configDir):
-                        os.makedirs(configDir)
+                        os.makedirs(configDir, exist_ok=True)
                     if os.access(configDir, os.W_OK):
                         defaultConfigFile = configFile # we can create it if we need to
                 except OSError:

--- a/python/eups/distrib/tarball.py
+++ b/python/eups/distrib/tarball.py
@@ -219,7 +219,7 @@ DIST_URL = %s
                 pass
 
         if not os.path.exists(unpackDir):
-            os.makedirs(unpackDir)
+            os.makedirs(unpackDir, exist_ok=True)
 
         if self.verbose > 0:
             print("installing %s into %s" % (tarball, unpackDir), file=self.log)

--- a/python/eups/lock.py
+++ b/python/eups/lock.py
@@ -39,7 +39,7 @@ def getLockPath(dirName, create=False):
 
         if create:
             if not os.path.exists(dirName):
-                os.makedirs(dirName)
+                os.makedirs(dirName, exist_ok=True)
 
         return dirName
 

--- a/python/eups/stack/ProductStack.py
+++ b/python/eups/stack/ProductStack.py
@@ -104,7 +104,7 @@ class ProductStack(object):
         self.persistDir = persistDir
         if self.persistDir is not None and self.autosave and \
            not os.path.exists(self.persistDir):
-              os.makedirs(self.persistDir)
+              os.makedirs(self.persistDir, exist_ok=True)
               # raise IOError("Directory not found: " + self.persistDir)
 
         # user tag assignments stored a hierarchical dictionary.  The

--- a/python/eups/utils.py
+++ b/python/eups/utils.py
@@ -322,7 +322,7 @@ def isDbWritable(dbpath, create=False):
 
     if not dbExists and create:
         try:
-            os.makedirs(dbpath)
+            os.makedirs(dbpath, exist_ok=True)
         except Exception as e:
             pass
         else:

--- a/tests/testDb.py
+++ b/tests/testDb.py
@@ -475,8 +475,7 @@ class DatabaseTestCase(unittest.TestCase):
     def setUp(self):
         self.dbpath = os.path.join(testEupsStack, "ups_db")
         self.userdb = os.path.join(testEupsStack, "user_ups_db")
-        if not os.path.exists(self.userdb):
-            os.makedirs(self.userdb)
+        os.makedirs(self.userdb, exist_ok=True)
 
         self.db = Database(self.dbpath, self.userdb)
 

--- a/tests/testDb.py
+++ b/tests/testDb.py
@@ -490,7 +490,7 @@ class DatabaseTestCase(unittest.TestCase):
 
         if os.path.exists(self.userdb) and self.userdb.endswith("user_ups_db"):
 
-            os.system("rm -rf " + self.userdb)
+            shutil.rmtree(self.userdb, ignore_errors=True)
 
     def testFindProductNames(self):
         prods = self.db.findProductNames()

--- a/tests/testEups.py
+++ b/tests/testEups.py
@@ -46,7 +46,7 @@ class EupsTestCase(unittest.TestCase):
 
         usercachedir = os.path.join(testEupsStack,"_userdata_","_caches_")
         if os.path.exists(usercachedir):
-            os.system('rm -rf "%s"' % usercachedir)
+            shutil.rmtree(usercachedir, ignore_errors=True)
 
         if os.path.exists(self.betachain):  os.remove(self.betachain)
 
@@ -552,7 +552,7 @@ class EupsCacheTestCase(unittest.TestCase):
     def tearDown(self):
         usercachedir = os.path.join(testEupsStack,"_userdata_","_caches_")
         if os.path.exists(usercachedir):
-            os.system("rm -rf " + usercachedir)
+            shutil.rmtree(usercachedir, ignore_errors=True)
 
         newprod = os.path.join(self.dbpath,"newprod")
         if os.path.exists(newprod):


### PR DESCRIPTION
This can happen if there is a race with another eups process trying to create the directory.