### PR TITLE
tickets/DM-52773: Improve `index.json` URL construction

### DIFF
--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -1070,9 +1070,6 @@ class WebTransporter(Transporter):
                 if tag == "address":
                     self.is_attribute = True
 
-                if tag == "a" and attributes[0][1].endswith('/'): # Adds rows for nginx server
-                    self.nrow += 1
-
                 if self.nrow <= 0 or tag != "a":
                     return
 

--- a/python/eups/distrib/server.py
+++ b/python/eups/distrib/server.py
@@ -12,6 +12,7 @@ import json
 import shutil
 import tempfile
 from pathlib import Path
+import posixpath
 import concurrent.futures
 from urllib.request import urlopen
 from urllib.error import HTTPError, URLError
@@ -1123,7 +1124,8 @@ class WebTransporter(Transporter):
         Index.json is a list of location of files.
         @param url      the url where the index file is located"""
         try:
-            with urlopen(url + '/index.json') as response:
+            indexurl = posixpath.join(url,"index.json")
+            with urlopen(indexurl) as response:
                 if response.status == 200:
                     files = json.loads(response.read().decode())
                     return files


### PR DESCRIPTION
Improve `index.json` URL construction.
Depending on how the pkgroot is passed, we might end up with a request to `{pkgroot}//index.json` instead of `{pkgroot}/index`. This change will correctly handling leading/trailing slashes in the `url`.
remove Nginx parsing workaround since we are no longer using nginx